### PR TITLE
Combine update and regenerate buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -319,21 +319,19 @@ for i, cert in enumerate(cert_rows, 1):
         approved = st.checkbox("✅ Approve this certificate", value=True, key=f"approve_{i}")
         indiv_comment = st.text_area("✏️ Reviewer Comment", "", placeholder="Optional feedback on this certificate", key=f"comment_{i}")
 
-        if st.button("🔄 Regenerate with Comment", key=f"regen_{i}"):
-            try:
-                regenerate_certificate(cert, global_comment, indiv_comment)
-                st.session_state.cert_rows[i-1] = cert
-                st.success("Certificate regenerated.")
-            except Exception as e:
-                st.error(str(e))
-
-        if st.button("📄 Update This Certificate", key=f"update_{i}"):
+        if st.button("📄 Apply Changes", key=f"apply_{i}"):
             cert["Name"] = name
             cert["Title"] = title
             cert["Organization"] = org
             cert["Certificate_Text"] = text
             cert["approved"] = approved
             cert["reviewer_comment"] = indiv_comment
+            if indiv_comment.strip():
+                try:
+                    regenerate_certificate(cert, global_comment, indiv_comment)
+                except Exception as e:
+                    st.error(str(e))
+            st.session_state.cert_rows[i-1] = cert
             st.success("Certificate updated.")
 
         final_cert_rows.append(cert)


### PR DESCRIPTION
## Summary
- replace the two certificate buttons with a single **Apply Changes** button
- update the certificate using widget values and call `regenerate_certificate` when a comment is provided

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c80c3174832c890d26a29b9f1f4a