### PR TITLE
Auto-save widget edits

### DIFF
--- a/app.py
+++ b/app.py
@@ -319,21 +319,19 @@ for i, cert in enumerate(cert_rows, 1):
         approved = st.checkbox("✅ Approve this certificate", value=True, key=f"approve_{i}")
         indiv_comment = st.text_area("✏️ Reviewer Comment", "", placeholder="Optional feedback on this certificate", key=f"comment_{i}")
 
-        if st.button("📄 Apply Changes", key=f"apply_{i}"):
-            cert["Name"] = name
-            cert["Title"] = title
-            cert["Organization"] = org
-            cert["Certificate_Text"] = text
-            cert["approved"] = approved
-            cert["reviewer_comment"] = indiv_comment
-            if indiv_comment.strip():
-                try:
-                    regenerate_certificate(cert, global_comment, indiv_comment)
-                except Exception as e:
-                    st.error(str(e))
-            st.session_state.cert_rows[i-1] = cert
-            st.success("Certificate updated.")
-
+        prev_comment = cert.get("reviewer_comment", "")
+        cert["Name"] = name
+        cert["Title"] = title
+        cert["Organization"] = org
+        cert["Certificate_Text"] = text
+        cert["approved"] = approved
+        cert["reviewer_comment"] = indiv_comment
+        if indiv_comment.strip() and indiv_comment != prev_comment:
+            try:
+                regenerate_certificate(cert, global_comment, indiv_comment)
+            except Exception as e:
+                st.error(str(e))
+        st.session_state.cert_rows[i-1] = cert
         final_cert_rows.append(cert)
 
         st.markdown("---")


### PR DESCRIPTION
## Summary
- immediately assign widget values to each certificate
- persist updates in `st.session_state`
- regenerate a certificate when reviewer comment changes

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851c8fb00bc832cb53886254275be1d