### PR TITLE
Add font size sync button

### DIFF
--- a/app.py
+++ b/app.py
@@ -351,6 +351,14 @@ for i, cert in enumerate(cert_rows, 1):
         with col2:
             text_size = st.number_input("Text Size", 10, 40, int(cert.get("Text_Size", 14)), key=f"text_size_{i}")
             date_size = st.number_input("Date Size", 8, 30, int(cert.get("Date_Size", 12)), key=f"date_size_{i}")
+        if st.button("📏 Apply Font Sizes to All", key=f"apply_sizes_{i}"):
+            for idx in range(len(st.session_state.cert_rows)):
+                st.session_state.cert_rows[idx]["Name_Size"] = name_size
+                st.session_state.cert_rows[idx]["Title_Size"] = title_size
+                st.session_state.cert_rows[idx]["Text_Size"] = text_size
+                st.session_state.cert_rows[idx]["Date_Size"] = date_size
+            cert_rows = st.session_state.cert_rows
+            st.success("Font sizes applied to all certificates.")
         approved = st.checkbox("✅ Approve this certificate", value=True, key=f"approve_{i}")
         indiv_comment = st.text_area("✏️ Reviewer Comment", "", placeholder="Optional feedback on this certificate", key=f"comment_{i}")
 


### PR DESCRIPTION
## Summary
- add a button inside each certificate entry to propagate font sizes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6851d6ed98a4832c9e1303ad9a5f9121