### PR TITLE
Improve event date handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai
 pandas
 pdfminer.six
 python-docx
+python-dateutil


### PR DESCRIPTION
## Summary
- add utility to parse event dates from request text
- prompt user for event date if none detected and apply it to all certificates
- update requirements with `python-dateutil`

## Testing
- `python -m py_compile app.py learned_preferences_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_6851eb043434832c9891dd9d18e81c71