### PR TITLE
Clarify host organization rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This version uses `pdfminer.six` for stable PDF text extraction on Streamlit Clo
    OPENAI_API_KEY = "sk-..."
    ```
 5. Done!
+
+## 📝 Certificate Extraction Guidelines
+
+When extracting certificate information, the app uses GPT to parse titles and organizations from event text. If an organization is hosting the event, its name should **not** be placed in the Title block for certificates associated with the host. Only include "Title of Organization" when an individual or group from that organization is being recognized by the host organization.

--- a/app.py
+++ b/app.py
@@ -166,6 +166,8 @@ You will be given the full text of a certificate request. Your task is to extrac
 - Carefully interpret the context of the event and the nature of each person's recognition
 - If more than one name or organization appears in a single entry, set \"possible_split\": true
 - If you're uncertain about name, title, or org, return multiple options inside \"alternatives\"
+- If an organization appears to be hosting the event, omit it from the recipient's title
+- Only include "title" of "organization" when someone from that organization is receiving recognition from the host
 
 Each certificate must include:
 - name


### PR DESCRIPTION
## Summary
- instruct GPT parser not to add host organizations into the Title field
- document the rule in the README

## Testing
- `python -m py_compile app.py learned_preferences_writer.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851f2fa3bbc832caf397e7ea53f4809