### PR TITLE
Add support for additional upload file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Certificate Generator (Streamlit + GPT-4o)
 
 This version uses `pdfminer.six` for stable PDF text extraction on Streamlit Cloud.
+You can also upload text, Word, Excel, CSV, and image files. Images are processed using OCR via Tesseract (make sure the `tesseract` binary is installed).
 
 ## 🚀 How to Deploy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ pandas
 pdfminer.six
 python-docx
 python-dateutil
+openpyxl
+pillow
+pytesseract


### PR DESCRIPTION
## Summary
- allow uploading PDF, Word, Excel, CSV, text and image files
- extract text from each supported file type, using OCR for images
- document new feature in README
- add dependencies for parsing new formats

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851fac1318c832cbf788f3c52c07b4d