### PR TITLE
Allow global comments to modify certificate fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ You can also upload text, Word, Excel, CSV, and image files. Images are processe
 ## 📝 Certificate Extraction Guidelines
 
 When extracting certificate information, the app uses GPT to parse titles and organizations from event text. If an organization is hosting the event, its name should **not** be placed in the Title block for certificates associated with the host. Only include "Title of Organization" when an individual or group from that organization is being recognized by the host organization.
+
+## ✨ Global Comments
+
+The **Global Comments** box can modify any certificate field. For example:
+
+- `Organization name for all certificates is "Acme Corp"` will set the organization on every certificate to "Acme Corp".
+- `Use organization instead of title` copies the organization value into the Title field for each certificate.
+
+After entering a global comment, click **Regenerate All Certificates** to apply the changes.


### PR DESCRIPTION
## Summary
- add `apply_global_comment` helper to handle simple global instructions
- update regenerate-all and individual regenerate actions to apply these rules
- document global comments in README

## Testing
- `python -m py_compile app.py learned_preferences_writer.py`

------
https://chatgpt.com/codex/tasks/task_e_6851fe6d8b94832cb9710c27c6d47a1f