### PR TITLE
Improve global comment replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ The **Global Comments** box can modify any certificate field. For example:
 
 - `Organization name for all certificates is "Acme Corp"` will set the organization on every certificate to "Acme Corp".
 - `Use organization instead of title` copies the organization value into the Title field for each certificate.
+- `Replace 'Officer' in title with organization` swaps the word "Officer" in every title with the certificate's organization.
 
 After entering a global comment, click **Regenerate All Certificates** to apply the changes.

--- a/app.py
+++ b/app.py
@@ -335,12 +335,27 @@ def apply_global_comment(cert_rows, global_comment):
         for cert in cert_rows:
             cert["Organization"] = org_value
 
-    # Replace the title with the organization text
+    # Replace the entire title with the organization text
     if ("use organization instead of title" in comment or
             "replace title with organization" in comment):
         for cert in cert_rows:
             cert["Title"] = cert.get("Organization", "")
-            cert["Title_Size"] = determine_title_font_size(format_display_title(cert["Title"], cert["Organization"]))
+            cert["Title_Size"] = determine_title_font_size(
+                format_display_title(cert["Title"], cert["Organization"])
+            )
+
+    # Replace a specific word in the title with the organization text
+    replace_word = re.search(
+        r"replace ['\"]?([^'\"]+)['\"]? in title with organization",
+        comment,
+    )
+    if replace_word:
+        target = replace_word.group(1).strip()
+        for cert in cert_rows:
+            cert["Title"] = cert.get("Title", "").replace(target, cert.get("Organization", ""))
+            cert["Title_Size"] = determine_title_font_size(
+                format_display_title(cert["Title"], cert["Organization"])
+            )
 
     return cert_rows
 


### PR DESCRIPTION
## Summary
- add ability to replace specific words in the title with the organization
- document new global comment example in README

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520082d188832ca8880a3c428d44d9