### PR TITLE
Fix variable name for logging certificates

### DIFF
--- a/app.py
+++ b/app.py
@@ -638,7 +638,7 @@ if st.button("📄 Generate Word Certificates"):
     if not approved_entries:
         st.error("No certificates were approved.")
     else:
-        log_certificates(parsed_entries, approved_entries, pdf_text, source="pdf" if pdf_file else "pasted", global_comment=global_comment)
+        log_certificates(parsed_entries, approved_entries, pdf_text, source=source_type, global_comment=global_comment)
         with st.spinner("Generating Word document..."):
             doc = generate_word_certificates(approved_entries)
             tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".docx")


### PR DESCRIPTION
## Summary
- fix undefined variable when logging certificate data

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68520987f994832c81a0fed30ae1c604