### PR TITLE
Add uniform commendation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ The **Global Comments** box can modify any certificate field. For example:
 - `Replace 'Officer' in title with organization` swaps the word "Officer" in every title with the certificate's organization.
 
 After entering a global comment, click **Regenerate All Certificates** to apply the changes.
+
+## 🏷️ Uniform Commendation
+
+When a request includes many certificates of the same type, you can apply a single commendation to every certificate in that category. After uploading your request and extracting the entries, the app displays a **Uniform Commendation by Category** section. Enter or paste the commendation text for each category and click **Apply Uniform Commendations**. The text will replace the generated commendation for all certificates in that category.

--- a/app.py
+++ b/app.py
@@ -225,6 +225,7 @@ Each certificate must include:
 - title
 - organization (if applicable)
 - date_raw (or fallback to event date)
+- category: short (2–3 word) description of the recognition type
 - commendation: 2–3 sentence message starting with "On behalf of the California State Legislature..." that honors their work and ends with well wishes
 - optional: possible_split (true/false)
 - optional: alternatives (dictionary)
@@ -251,6 +252,7 @@ Return ONLY valid JSON.
         name = parsed.get("name") or "Recipient"
         title = parsed.get("title") or ""
         org = parsed.get("organization") or ""
+        category = parsed.get("category", "General")
         commendation = parsed.get("commendation") or ""
 
         if title.strip().lower() == "certificate of recognition":
@@ -265,6 +267,7 @@ Return ONLY valid JSON.
             "Organization": org,
             "Certificate_Text": commendation,
             "Formatted_Date": format_certificate_date(parsed.get("date_raw") or event_date),
+            "Category": category,
             "Tone_Category": "📝",
             "possible_split": parsed.get("possible_split", False),
             "alternatives": parsed.get("alternatives", {}),
@@ -434,6 +437,30 @@ else:
 for cert in cert_rows:
     if st.session_state.event_date_raw.strip():
         cert["Formatted_Date"] = st.session_state.formatted_event_date
+
+# Allow user to apply a single commendation to all certificates in a category
+categories = sorted({c.get("Category", "General") for c in cert_rows})
+if "uniform_texts" not in st.session_state:
+    st.session_state.uniform_texts = {cat: "" for cat in categories}
+
+st.subheader("🏷️ Uniform Commendation by Category")
+st.write(
+    "Optionally generate or enter a commendation that will be applied to every certificate in the same category."
+)
+for cat in categories:
+    key_text = f"uniform_text_{cat}"
+    st.session_state.uniform_texts.setdefault(cat, "")
+    st.session_state.uniform_texts[cat] = st.text_area(
+        f"{cat} Commendation", value=st.session_state.uniform_texts[cat], key=key_text
+    )
+
+if st.button("Apply Uniform Commendations", key="apply_uniform"):
+    for cert in cert_rows:
+        text = st.session_state.uniform_texts.get(cert.get("Category", "General"), "").strip()
+        if text:
+            cert["Certificate_Text"] = text
+    st.session_state.cert_rows = cert_rows
+    st.success("Uniform commendations applied.")
 
 st.subheader("💬 Global Comments")
 global_comment = st.text_area(


### PR DESCRIPTION
## Summary
- add a `category` field when extracting certificates
- allow defining a single commendation for each category
- document the new uniform commendation workflow

## Testing
- `python -m py_compile app.py learned_preferences_writer.py`

------
https://chatgpt.com/codex/tasks/task_e_68520c1b1054832c844158dae8a41356