### PR TITLE
Add uniform commendation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ The **Global Comments** box can modify any certificate field. For example:
 - `Replace 'Officer' in title with organization` swaps the word "Officer" in every title with the certificate's organization.
 
 After entering a global comment, click **Regenerate All Certificates** to apply the changes.
+
+## 🏷️ Uniform Commendation
+
+If you want the same message across all certificates, enter it once and click **Apply Uniform Commendation**. The text will be copied to every certificate so you only need to make small tweaks for different recognition types.

--- a/app.py
+++ b/app.py
@@ -225,6 +225,7 @@ Each certificate must include:
 - title
 - organization (if applicable)
 - date_raw (or fallback to event date)
+- category: short (2–3 word) description of the recognition type
 - commendation: 2–3 sentence message starting with "On behalf of the California State Legislature..." that honors their work and ends with well wishes
 - optional: possible_split (true/false)
 - optional: alternatives (dictionary)
@@ -251,6 +252,7 @@ Return ONLY valid JSON.
         name = parsed.get("name") or "Recipient"
         title = parsed.get("title") or ""
         org = parsed.get("organization") or ""
+        category = parsed.get("category", "General")
         commendation = parsed.get("commendation") or ""
 
         if title.strip().lower() == "certificate of recognition":
@@ -265,6 +267,7 @@ Return ONLY valid JSON.
             "Organization": org,
             "Certificate_Text": commendation,
             "Formatted_Date": format_certificate_date(parsed.get("date_raw") or event_date),
+            "Category": category,
             "Tone_Category": "📝",
             "possible_split": parsed.get("possible_split", False),
             "alternatives": parsed.get("alternatives", {}),
@@ -434,6 +437,22 @@ else:
 for cert in cert_rows:
     if st.session_state.event_date_raw.strip():
         cert["Formatted_Date"] = st.session_state.formatted_event_date
+
+# Optionally apply one commendation to all certificates
+if "uniform_text" not in st.session_state:
+    st.session_state.uniform_text = ""
+
+st.subheader("🏷️ Uniform Commendation")
+use_uniform = st.checkbox("Use the same commendation for all certificates", value=False, key="use_uniform")
+if use_uniform:
+    st.session_state.uniform_text = st.text_area("Uniform Commendation Text", value=st.session_state.uniform_text, key="uniform_text")
+    if st.button("Apply Uniform Commendation", key="apply_uniform"):
+        uniform = st.session_state.uniform_text.strip()
+        if uniform:
+            for cert in cert_rows:
+                cert["Certificate_Text"] = uniform
+            st.session_state.cert_rows = cert_rows
+            st.success("Uniform commendation applied to all certificates.")
 
 st.subheader("💬 Global Comments")
 global_comment = st.text_area(


### PR DESCRIPTION
## Summary
- simplify UI with a single "Uniform Commendation" option
- document the streamlined flow in README

## Testing
- `python -m py_compile app.py learned_preferences_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_68520c1b1054832c844158dae8a41356