### PR TITLE
Add uniform commendation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ The **Global Comments** box can modify any certificate field. For example:
 - `Replace 'Officer' in title with organization` swaps the word "Officer" in every title with the certificate's organization.
 
 After entering a global comment, click **Regenerate All Certificates** to apply the changes.
+
+## 🏷️ Uniform Commendation by Category
+
+When uploading your request you can choose **Use uniform commendation per category**. After the certificates are extracted, a text box for each category appears. Enter one commendation per category and click **Apply Uniform Commendations** to copy it to all certificates in that group.

--- a/app.py
+++ b/app.py
@@ -225,6 +225,7 @@ Each certificate must include:
 - title
 - organization (if applicable)
 - date_raw (or fallback to event date)
+- category: short (2–3 word) description of the recognition type
 - commendation: 2–3 sentence message starting with "On behalf of the California State Legislature..." that honors their work and ends with well wishes
 - optional: possible_split (true/false)
 - optional: alternatives (dictionary)
@@ -251,6 +252,7 @@ Return ONLY valid JSON.
         name = parsed.get("name") or "Recipient"
         title = parsed.get("title") or ""
         org = parsed.get("organization") or ""
+        category = parsed.get("category", "General")
         commendation = parsed.get("commendation") or ""
 
         if title.strip().lower() == "certificate of recognition":
@@ -265,6 +267,7 @@ Return ONLY valid JSON.
             "Organization": org,
             "Certificate_Text": commendation,
             "Formatted_Date": format_certificate_date(parsed.get("date_raw") or event_date),
+            "Category": category,
             "Tone_Category": "📝",
             "possible_split": parsed.get("possible_split", False),
             "alternatives": parsed.get("alternatives", {}),
@@ -388,6 +391,14 @@ uploaded_file = st.file_uploader(
 )
 text_input = st.text_area("Or paste certificate request text here", height=300)
 
+if "use_uniform_by_category" not in st.session_state:
+    st.session_state.use_uniform_by_category = False
+
+st.session_state.use_uniform_by_category = st.checkbox(
+    "Use uniform commendation per category",
+    value=st.session_state.use_uniform_by_category,
+)
+
 if not uploaded_file and not text_input.strip():
     st.warning("Please upload a file or paste request text.")
     st.stop()
@@ -434,6 +445,50 @@ else:
 for cert in cert_rows:
     if st.session_state.event_date_raw.strip():
         cert["Formatted_Date"] = st.session_state.formatted_event_date
+
+if st.session_state.use_uniform_by_category:
+    if "category_uniform_texts" not in st.session_state:
+        st.session_state.category_uniform_texts = {}
+    st.subheader("🏷️ Uniform Commendation by Category")
+    categories = sorted({c.get("Category", "General") for c in cert_rows})
+    for cat in categories:
+        key = f"uniform_{cat.replace(' ', '_')}"
+        st.session_state.category_uniform_texts.setdefault(cat, "")
+        st.session_state.category_uniform_texts[cat] = st.text_area(
+            f"{cat} Commendation",
+            value=st.session_state.category_uniform_texts[cat],
+            key=key,
+        )
+    if st.button("Apply Uniform Commendations", key="apply_uniform_by_cat"):
+        for cert in cert_rows:
+            cat = cert.get("Category", "General")
+            uniform = st.session_state.category_uniform_texts.get(cat, "").strip()
+            if uniform:
+                cert["Certificate_Text"] = uniform
+        st.session_state.cert_rows = cert_rows
+        st.success("Uniform commendations applied by category.")
+else:
+    if "uniform_text" not in st.session_state:
+        st.session_state.uniform_text = ""
+    st.subheader("🏷️ Uniform Commendation")
+    use_uniform = st.checkbox(
+        "Use the same commendation for all certificates",
+        value=False,
+        key="use_uniform",
+    )
+    if use_uniform:
+        st.session_state.uniform_text = st.text_area(
+            "Uniform Commendation Text",
+            value=st.session_state.uniform_text,
+            key="uniform_text",
+        )
+        if st.button("Apply Uniform Commendation", key="apply_uniform"):
+            uniform = st.session_state.uniform_text.strip()
+            if uniform:
+                for cert in cert_rows:
+                    cert["Certificate_Text"] = uniform
+                st.session_state.cert_rows = cert_rows
+                st.success("Uniform commendation applied to all certificates.")
 
 st.subheader("💬 Global Comments")
 global_comment = st.text_area(


### PR DESCRIPTION
## Summary
- allow enabling uniform commendations by category during upload
- document how uniform commendations work in README

## Testing
- `python -m py_compile app.py learned_preferences_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_68520c1b1054832c844158dae8a41356