### PR TITLE
Add uniform commendation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ The **Global Comments** box can modify any certificate field. For example:
 - `Replace 'Officer' in title with organization` swaps the word "Officer" in every title with the certificate's organization.
 
 After entering a global comment, click **Regenerate All Certificates** to apply the changes.
+
+## 🏷️ Uniform Commendation by Category
+
+Before generating certificates you can enable **Use uniform commendation per category**. When selected, the app asks GPT to produce one sample commendation for each category and applies it to every certificate in that group. You can adjust the text in the provided boxes and click **Apply Uniform Commendations** to update all certificates at once.


### PR DESCRIPTION
## Summary
- allow enabling uniform commendations by category during upload
- auto-generate one commendation for each category
- document uniform commendations in README

## Testing
- `python -m py_compile app.py learned_preferences_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_68520c1b1054832c844158dae8a41356