### PR TITLE
Fix main logo path

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -5,7 +5,7 @@ st.set_page_config(page_title="LegAid", page_icon="📜", layout="wide")
 st.markdown(
     """
     <div style='text-align:center; padding:2rem 0;'>
-        <img src='assets/logo.png' width='150' alt='LegAid logo'>
+        <img src='Assets/MainLogo.png' width='150' alt='LegAid logo'>
         <h1 style='margin-bottom:0;'>LegAid</h1>
         <h4 style='margin-top:0; color: gray;'>Tools for Legislative Productivity</h4>
     </div>


### PR DESCRIPTION
## Summary
- show the main logo correctly in the main page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852cbe35ba8832c8d6a7c76277c7167