### PR TITLE
Update homepage logo and remove brand text

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 from pathlib import Path
 import base64
 
-st.set_page_config(page_title="LegAid", page_icon="📜", layout="wide")
+st.set_page_config(page_title="Legislative Tools", page_icon="📜", layout="wide")
 
 logo_path = Path(__file__).parent / "Assets" / "MainLogo.png"
 with open(logo_path, "rb") as f:
@@ -11,8 +11,7 @@ with open(logo_path, "rb") as f:
 st.markdown(
     f"""
     <div style='text-align:center; padding:2rem 0;'>
-        <img src='data:image/png;base64,{encoded}' width='150' alt='LegAid logo'>
-        <h1 style='margin-bottom:0;'>LegAid</h1>
+        <img src='data:image/png;base64,{encoded}' width='600' alt='Application logo'>
         <h4 style='margin-top:0; color: gray;'>Tools for Legislative Productivity</h4>
     </div>
     """,


### PR DESCRIPTION
## Summary
- drop `LegAid` title from the landing page
- increase homepage logo size

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852d3924924832c8c95967176abf2b7