### PR TITLE
Change CertCreations to CertCreate

### DIFF
--- a/LegAid/pages/1_Certificate_Generator.py
+++ b/LegAid/pages/1_Certificate_Generator.py
@@ -414,7 +414,7 @@ def split_certificate(index):
     st.session_state.expand_after_split = [index, index + 1]
 
 st.set_page_config(layout="centered")
-st.title("📁 CertCreations")
+st.title("📁 CertCreate")
 
 if "started" not in st.session_state:
     st.session_state.started = False


### PR DESCRIPTION
## Summary
- rename CertCreations page title to CertCreate

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m py_compile LegAid/pages/1_Certificate_Generator.py`


------
https://chatgpt.com/codex/tasks/task_e_6852d715c4b8832cbf26b222635dee0d