### PR TITLE
Enable PDF certificate output

### DIFF
--- a/LegAid/requirements.txt
+++ b/LegAid/requirements.txt
@@ -7,3 +7,4 @@ python-dateutil
 openpyxl
 pillow
 pytesseract
+reportlab

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The certificate generator is now part of **LegAid**, a multi‑page Streamlit ap
 It still relies on `pdfminer.six` for stable PDF text extraction and supports text, Word, Excel,
 CSV and image uploads. Images are processed using OCR via Tesseract (ensure the
 `tesseract` binary is installed).
+Generated certificates can be downloaded as Word documents or as PDFs.
 
 Run the entire suite with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dateutil
 openpyxl
 pillow
 pytesseract
+reportlab


### PR DESCRIPTION
## Summary
- allow certificate download as PDF in addition to DOCX
- add reportlab dependency
- mention PDF export in README

## Testing
- `python -m py_compile LegAid/pages/1_Certificate_Generator.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6852d86df89c832c889295d5b2a6be9e