### PR TITLE
UI tweaks and workflow fixes

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -2,7 +2,12 @@ import streamlit as st
 from pathlib import Path
 import base64
 
-st.set_page_config(page_title="Legislative Tools", page_icon="📜", layout="wide")
+st.set_page_config(
+    page_title="Legislative Tools",
+    page_icon="📜",
+    layout="wide",
+    initial_sidebar_state="collapsed",
+)
 
 logo_path = Path(__file__).parent / "Assets" / "MainLogo.png"
 with open(logo_path, "rb") as f:
@@ -18,4 +23,14 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-st.write("Select a tool from the sidebar to begin.")
+st.write("Select a tool below to begin.")
+
+col1, col2, col3, col4 = st.columns(4)
+with col1:
+    st.page_link("LegAid/pages/1_CertCreate.py", label="CertCreate")
+with col2:
+    st.page_link("LegAid/pages/2_SpeechCreate.py", label="SpeechCreate")
+with col3:
+    st.page_link("LegAid/pages/3_ResponseCreate.py", label="ResponseCreate")
+with col4:
+    st.page_link("LegAid/pages/4_LegCreate.py", label="LegCreate")

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -2,8 +2,11 @@ import streamlit as st
 from utils.shared_functions import example_helper
 
 
+st.set_page_config(layout="centered")
+st.title("📝 SpeechCreate")
+
+
 def render_speech_writer():
-    st.markdown("## 📝 **Speech Writer**")
     st.write("Compose speeches with AI assistance.")
 
     st.text_area("Speech Topic", height=100)

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -2,8 +2,11 @@ import streamlit as st
 from utils.shared_functions import example_helper
 
 
+st.set_page_config(layout="centered")
+st.title("📬 ResponseCreate")
+
+
 def render_constituent_response():
-    st.markdown("## 📬 **Constituent Response Generator**")
     st.write("Draft replies to constituent inquiries.")
 
     st.text_area("Constituent Question", height=100)

--- a/LegAid/pages/4_LegCreate.py
+++ b/LegAid/pages/4_LegCreate.py
@@ -2,8 +2,11 @@ import streamlit as st
 from utils.shared_functions import example_helper
 
 
+st.set_page_config(layout="centered")
+st.title("📚 LegCreate")
+
+
 def render_knowledge_center():
-    st.markdown("## 📚 **Knowledge Center**")
     st.write("Access legislative resources and references.")
 
     st.text_input("Search Resources")


### PR DESCRIPTION
## Summary
- rename page files and update titles
- add navigation links on the main page
- enhance manual certificate form UI
- allow removing a certificate and set default mode on reset
- tweak download label

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852ff1d7370832caebe9d361904ea9a