### PR TITLE
Implement UI updates and add MailCreate page

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -1,13 +1,15 @@
 import streamlit as st
 from pathlib import Path
 import base64
+from utils.navigation import render_sidebar
 
 st.set_page_config(
     page_title="Legislative Tools",
     page_icon="📜",
     layout="wide",
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="expanded",
 )
+render_sidebar()
 
 logo_path = Path(__file__).parent / "Assets" / "MainLogo.png"
 with open(logo_path, "rb") as f:
@@ -19,13 +21,22 @@ st.markdown(
         <img src='data:image/png;base64,{encoded}' width='600' alt='Application logo'>
         <h4 style='margin-top:0; color: gray;'>Tools for Legislative Productivity</h4>
     </div>
+    <style>
+    a[data-testid="stPageLink"] {
+        display:inline-block;
+        padding:0.5rem 1rem;
+        background:#eee;
+        border:1px solid #ccc;
+        border-radius:4px;
+        margin:0 0.2rem;
+        text-decoration:none;
+    }
+    </style>
     """,
     unsafe_allow_html=True,
 )
 
-st.write("Select a tool below to begin.")
-
-col1, col2, col3, col4 = st.columns(4)
+col1, col2, col3, col4, col5 = st.columns(5)
 with col1:
     st.page_link("pages/1_CertCreate.py", label="CertCreate")
 with col2:
@@ -33,4 +44,6 @@ with col2:
 with col3:
     st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
 with col4:
-    st.page_link("pages/4_LegCreate.py", label="LegCreate")
+    st.page_link("pages/4_LegTrack.py", label="LegTrack")
+with col5:
+    st.page_link("pages/5_MailCreate.py", label="MailCreate")

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -1,8 +1,11 @@
 import streamlit as st
 from utils.shared_functions import example_helper
+from utils.navigation import render_sidebar, render_logo
 
 
-st.set_page_config(layout="centered")
+st.set_page_config(layout="centered", initial_sidebar_state="expanded")
+render_sidebar()
+render_logo()
 st.title("📬 ResponseCreate")
 
 

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -1,9 +1,13 @@
 import streamlit as st
+from pathlib import Path
 from utils.shared_functions import example_helper
+from utils.navigation import render_sidebar, render_logo
 
 
-st.set_page_config(layout="centered")
-st.title("📚 LegCreate")
+st.set_page_config(layout="centered", initial_sidebar_state="expanded")
+render_sidebar()
+render_logo()
+st.title("📚 LegTrack")
 
 
 def render_knowledge_center():

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -2,19 +2,17 @@ import streamlit as st
 from utils.shared_functions import example_helper
 from utils.navigation import render_sidebar, render_logo
 
-
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.title("📝 SpeechCreate")
+st.title("📮 MailCreate")
 
 
-def render_speech_writer():
-    st.write("Compose speeches with AI assistance.")
-
-    st.text_area("Speech Topic", height=100)
-    st.button("Draft Speech")
+def render_mail_creator():
+    st.write("Draft formal mail pieces.")
+    st.text_area("Mail Content", height=100)
+    st.button("Generate Mail")
 
 
 if __name__ == "__main__":
-    render_speech_writer()
+    render_mail_creator()

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -1,0 +1,26 @@
+import streamlit as st
+from pathlib import Path
+import base64
+
+
+def render_sidebar(on_certcreate=None):
+    with st.sidebar:
+        st.page_link("app.py", label="LegAid")
+        if on_certcreate:
+            st.button("CertCreate", on_click=on_certcreate)
+        else:
+            st.page_link("pages/1_CertCreate.py", label="CertCreate")
+        st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate")
+        st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
+        st.page_link("pages/4_LegTrack.py", label="LegTrack")
+        st.page_link("pages/5_MailCreate.py", label="MailCreate")
+
+
+def render_logo():
+    logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
+    with open(logo_path, "rb") as f:
+        encoded = base64.b64encode(f.read()).decode()
+    st.markdown(
+        f"<a href='../app.py'><img src='data:image/png;base64,{encoded}' width='300' style='position:absolute;top:10px;right:10px;'></a>",
+        unsafe_allow_html=True,
+    )


### PR DESCRIPTION
## Summary
- add navigation helper module with sidebar and logo rendering
- redesign main page links as buttons and expand sidebar by default
- open certificate options with reset button and new defaults
- rename LegCreate to LegTrack and add MailCreate page
- tweak certificate generation layout and wording

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68530a7b67b8832c9bb4bd1ba4649535