### PR TITLE
UI improvements and uniform text editing

### DIFF
--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -6,7 +6,7 @@ from utils.navigation import render_sidebar, render_logo
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.title("📝 SpeechCreate")
+st.title("🗣️ SpeechCreate")
 
 
 def render_speech_writer():

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -6,7 +6,7 @@ from utils.navigation import render_sidebar, render_logo
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.title("📬 ResponseCreate")
+st.title("📧 ResponseCreate")
 
 
 def render_constituent_response():

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -7,7 +7,7 @@ from utils.navigation import render_sidebar, render_logo
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.title("📚 LegTrack")
+st.title("🔍 LegTrack")
 
 
 def render_knowledge_center():

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.title("📮 MailCreate")
+st.title("✉️ MailCreate")
 
 
 def render_mail_creator():

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -4,6 +4,10 @@ import base64
 
 
 def render_sidebar(on_certcreate=None):
+    st.markdown(
+        "<style>[data-testid='stSidebarNav']{display:none;}</style>",
+        unsafe_allow_html=True,
+    )
     with st.sidebar:
         st.page_link("app.py", label="LegAid")
         if on_certcreate:
@@ -21,6 +25,6 @@ def render_logo():
     with open(logo_path, "rb") as f:
         encoded = base64.b64encode(f.read()).decode()
     st.markdown(
-        f"<a href='../app.py'><img src='data:image/png;base64,{encoded}' width='300' style='position:absolute;top:10px;right:10px;'></a>",
+        f"<a href='../app.py'><img src='data:image/png;base64,{encoded}' width='80' style='position:absolute;top:10px;right:10px;z-index:1000;'></a>",
         unsafe_allow_html=True,
     )


### PR DESCRIPTION
## Summary
- hide duplicate navigation links in sidebar
- shrink floating logo and adjust z-index
- add editable uniform certificate text with Apply All option
- fix safe rerun usage when starting new request
- update page header emojis and remove manual form borders
- allow adding new certificates after completion

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853165a7168832c9e9991dcd7bf0d44