### PR TITLE
Fix certificate generation error and update UI

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -14,6 +14,7 @@ render_sidebar()
 logo_path = Path(__file__).parent / "Assets" / "MainLogo.png"
 with open(logo_path, "rb") as f:
     encoded = base64.b64encode(f.read()).decode()
+logo_small = f"<img src='data:image/png;base64,{encoded}' width='20' style='vertical-align:middle;margin-right:4px;'>"
 
 st.markdown(
     f"""
@@ -38,12 +39,17 @@ st.markdown(
 
 col1, col2, col3, col4, col5 = st.columns(5)
 with col1:
+    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/1_CertCreate.py", label="CertCreate")
 with col2:
+    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate")
 with col3:
+    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
 with col4:
+    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/4_LegTrack.py", label="LegTrack")
 with col5:
+    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/5_MailCreate.py", label="MailCreate")

--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -18,7 +18,7 @@ from reportlab.lib.pagesizes import letter
 from reportlab.lib.units import inch
 from reportlab.pdfgen import canvas
 import pandas as pd
-from PIL import Image
+from PIL import Image, ImageOps
 import pytesseract
 import random
 
@@ -144,6 +144,12 @@ def format_display_title(title: str, org: str) -> str:
 
     return title_clean or org_clean
 
+def normalize_spacing(text: str) -> str:
+    """Return text with excess whitespace removed."""
+    cleaned = re.sub(r"\s+", " ", text)
+    cleaned = cleaned.replace(" ,", ",").replace(" .", ".")
+    return cleaned.strip()
+
 def enhanced_commendation(name: str, title: str, org: str) -> str:
     """Return a default commendation around the TEXT_MAX_CHARS length."""
     parts = [
@@ -222,6 +228,12 @@ def read_uploaded_file(uploaded_file):
         elif suffix == ".docx":
             doc = Document(tmp_path)
             text = "\n".join(p.text for p in doc.paragraphs)
+        elif suffix == ".doc":
+            try:
+                import docx2txt
+                text = docx2txt.process(tmp_path)
+            except Exception:
+                text = ""
         elif suffix in {".xlsx", ".xls"}:
             df = pd.read_excel(tmp_path, header=None)
             lines = []
@@ -232,7 +244,8 @@ def read_uploaded_file(uploaded_file):
             text = "\n".join(lines)
         elif suffix in {".png", ".jpg", ".jpeg"}:
             try:
-                text = pytesseract.image_to_string(Image.open(tmp_path))
+                img = ImageOps.exif_transpose(Image.open(tmp_path))
+                text = pytesseract.image_to_string(img)
             except Exception:
                 text = ""
         return text, suffix.lstrip(".")
@@ -371,6 +384,7 @@ Return ONLY valid JSON.
             commendation = commendation.replace("{name}", name)
             commendation = commendation.replace("{title}", title)
             commendation = commendation.replace("{organization}", org)
+            commendation = normalize_spacing(commendation)
         else:
             commendation = parsed.get("commendation") or ""
 
@@ -411,7 +425,7 @@ def regenerate_certificate(cert, global_comment="", reviewer_comment=""):
 
     prompt = "\n".join(instructions)
     system = (
-        "You update certificate details based on reviewer comments. "
+        "You update certificate details based on reviewer comments and correct grammar. "
         f"Name must be \u2264 {NAME_MAX_CHARS} characters. Title must be \u2264 {TITLE_MAX_CHARS} characters. "
         f"Certificate text must not exceed {TEXT_MAX_CHARS} characters and {TEXT_MAX_LINES} lines. "
         "Return ONLY valid JSON with keys name, title, organization, date_raw, commendation."
@@ -486,7 +500,7 @@ def apply_global_comment(cert_rows, global_comment):
 def improve_certificate(cert):
     """Use GPT to suggest improvements for a manually entered certificate."""
     system = (
-        "You suggest concise improvements for a certificate entry. "
+        "You suggest concise improvements and correct grammar for a certificate entry. "
         f"Name must be <= {NAME_MAX_CHARS} characters. "
         f"Title must be <= {TITLE_MAX_CHARS} characters. "
         f"Certificate text must be <= {TEXT_MAX_CHARS} characters and {TEXT_MAX_LINES} lines. "
@@ -638,7 +652,7 @@ if not st.session_state.started:
                 "Date (e.g., May 31, 2024)", value=cert.get("Date", ""), key=f"m_date_{i}"
             )
 
-            if st.button("Make Improvements", key=f"improve_{i}"):
+            if st.button("Ask LegAid to Make Improvements", key=f"improve_{i}"):
                 improved = improve_certificate(cert)
                 st.session_state[f"improved_{i}"] = improved
                 safe_rerun()
@@ -649,8 +663,16 @@ if not st.session_state.started:
                     st.markdown("##### Suggested Improvements")
                 with right:
                     c1, c2 = st.columns(2)
-                    apply_btn = c1.button("Apply Improvements", key=f"apply_{i}")
+                    apply_btn = c1.button("Apply", key=f"apply_{i}")
                     keep_btn = c2.button("Keep Original", key=f"keep_{i}")
+                    c1.markdown(
+                        f"<style>button#apply_{i} {{background-color:green;color:white;}}</style>",
+                        unsafe_allow_html=True,
+                    )
+                    c2.markdown(
+                        f"<style>button#keep_{i} {{background-color:red;color:white;}}</style>",
+                        unsafe_allow_html=True,
+                    )
                 preview = certificate_preview_html(
                     st.session_state[f"improved_{i}"]["name"],
                     st.session_state[f"improved_{i}"]["title"],
@@ -798,7 +820,7 @@ if use_uniform and uniform_template:
                 .replace("{title}", cert["Title"])
                 .replace("{organization}", cert["Organization"])
             )
-            cert["Certificate_Text"] = text
+            cert["Certificate_Text"] = normalize_spacing(text)
         st.session_state.cert_rows = cert_rows
         uniform_template = uniform_edit
 
@@ -880,7 +902,7 @@ for i, cert in enumerate(cert_rows, 1):
         cert["approved"] = approved
         cert["reviewer_comment"] = indiv_comment
 
-        if st.button("🔄 ReCreate Certificate", key=f"regen_{i}"):
+        if st.button("🔄 ReCreate", key=f"regen_{i}"):
             if indiv_comment.strip():
                 try:
                     apply_global_comment([cert], global_comment)
@@ -960,6 +982,7 @@ if st.session_state.get("show_add"):
         st.session_state.show_add = False
         safe_rerun()
 
+st.markdown("<br><br>", unsafe_allow_html=True)
 
 def generate_word_certificates(entries):
     doc = Document()
@@ -991,26 +1014,29 @@ def generate_word_certificates(entries):
         title_size = TITLE_MAX_SIZE if display_title.strip() else 0
         text_size = TEXT_MAX_SIZE
 
-        p_name = doc.add_paragraph(entry["Name"])
+        p_name = doc.add_paragraph()
+        run_name = p_name.add_run(entry["Name"])
         p_name.alignment = WD_ALIGN_PARAGRAPH.CENTER
-        p_name.runs[0].bold = True
-        p_name.runs[0].font.name = "Times New Roman"
-        p_name.runs[0].font.size = Pt(name_size)
+        run_name.bold = True
+        run_name.font.name = "Times New Roman"
+        run_name.font.size = Pt(name_size)
         p_name.paragraph_format.space_after = Pt(3)
 
         display_title = format_display_title(entry["Title"], entry["Organization"])
         if display_title.strip():
-            p_title = doc.add_paragraph(display_title)
+            p_title = doc.add_paragraph()
+            run_title = p_title.add_run(display_title)
             p_title.alignment = WD_ALIGN_PARAGRAPH.CENTER
-            p_title.runs[0].bold = True
-            p_title.runs[0].font.name = "Times New Roman"
-            p_title.runs[0].font.size = Pt(title_size)
+            run_title.bold = True
+            run_title.font.name = "Times New Roman"
+            run_title.font.size = Pt(title_size)
 
-        p_text = doc.add_paragraph(entry["Certificate_Text"])
+        p_text = doc.add_paragraph()
+        run_text = p_text.add_run(entry["Certificate_Text"])
         p_text.alignment = WD_ALIGN_PARAGRAPH.CENTER
         p_text.paragraph_format.space_before = Pt(18)
-        p_text.runs[0].font.name = "Times New Roman"
-        p_text.runs[0].font.size = Pt(text_size)
+        run_text.font.name = "Times New Roman"
+        run_text.font.size = Pt(text_size)
 
         # Spacer to position date block starting at 8.25" from the top
         spacer_gap = doc.add_paragraph()
@@ -1018,12 +1044,13 @@ def generate_word_certificates(entries):
         spacer_gap.add_run(" ").font.size = Pt(12)
 
         for idx, line in enumerate(entry["Formatted_Date"].split("\n")):
-            p_date = doc.add_paragraph(line)
+            p_date = doc.add_paragraph()
+            run_date = p_date.add_run(line)
             p_date.alignment = WD_ALIGN_PARAGRAPH.CENTER
             p_date.paragraph_format.space_before = Pt(0 if idx > 0 else 0)
             p_date.paragraph_format.space_after = Pt(0)
-            p_date.runs[0].font.name = "Times New Roman"
-            p_date.runs[0].font.size = Pt(entry.get("Date_Size", 12))
+            run_date.font.name = "Times New Roman"
+            run_date.font.size = Pt(entry.get("Date_Size", 12))
 
         # Spacer before signature block (1.25")
         sig_spacer = doc.add_paragraph()
@@ -1126,7 +1153,7 @@ else:
     doc.save(tmp_docx.name)
     tmp_docx.seek(0)
     if st.download_button(
-        label="CreateCert Word",
+        label="**CreateCert** Word Doc",
         data=tmp_docx.read(),
         file_name="Certificates.docx",
         mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -1141,7 +1168,7 @@ else:
 
     pdf_bytes = generate_pdf_certificates(approved_entries)
     if st.download_button(
-        label="CreateCert PDF",
+        label="**CreateCert** PDF",
         data=pdf_bytes,
         file_name="Certificates.pdf",
         mime="application/pdf",

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -8,15 +8,24 @@ def render_sidebar(on_certcreate=None):
         "<style>[data-testid='stSidebarNav']{display:none;}</style>",
         unsafe_allow_html=True,
     )
+    logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
+    with open(logo_path, "rb") as f:
+        encoded = base64.b64encode(f.read()).decode()
+    logo_small = f"<img src='data:image/png;base64,{encoded}' width='20' style='vertical-align:middle;margin-right:4px;'>"
     with st.sidebar:
         st.page_link("app.py", label="LegAid")
         if on_certcreate:
             st.button("CertCreate", on_click=on_certcreate)
         else:
+            st.markdown(logo_small, unsafe_allow_html=True)
             st.page_link("pages/1_CertCreate.py", label="CertCreate")
+        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate")
+        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
+        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/4_LegTrack.py", label="LegTrack")
+        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/5_MailCreate.py", label="MailCreate")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ openpyxl
 pillow
 pytesseract
 reportlab
+docx2txt


### PR DESCRIPTION
## Summary
- fix IndexError when certificate name/title/date fields are empty
- trim extra spaces after placeholder replacements
- support `.doc` files and better image OCR
- improve grammar suggestions with OpenAI
- tweak button texts and add basic styling
- display small logo on main and sidebar navigation
- update requirements

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py LegAid/utils/navigation.py LegAid/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685343190684832cb92f4c3854896b4b