### PR TITLE
Fix small logo usage in headers

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -38,12 +38,12 @@ st.markdown(
 
 col1, col2, col3, col4, col5 = st.columns(5)
 with col1:
-    st.page_link("pages/1_CertCreate.py", label="CertCreate")
+    st.page_link("pages/1_CertCreate.py", label="CertCreate", icon=None)
 with col2:
-    st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate")
+    st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate", icon=None)
 with col3:
-    st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
+    st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate", icon=None)
 with col4:
-    st.page_link("pages/4_LegTrack.py", label="LegTrack")
+    st.page_link("pages/4_LegTrack.py", label="LegTrack", icon=None)
 with col5:
-    st.page_link("pages/5_MailCreate.py", label="MailCreate")
+    st.page_link("pages/5_MailCreate.py", label="MailCreate", icon=None)

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -1,12 +1,16 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo
+from utils.navigation import render_sidebar, SMALL_LOGO_HTML
 
 
-st.set_page_config(layout="centered", initial_sidebar_state="expanded")
+st.set_page_config(
+    layout="centered",
+    initial_sidebar_state="expanded",
+    page_title="SpeechCreate",
+    page_icon=None,
+)
 render_sidebar()
-render_logo()
-st.title("🗣️ SpeechCreate")
+st.markdown(f"<h1>{SMALL_LOGO_HTML} SpeechCreate</h1>", unsafe_allow_html=True)
 
 
 def render_speech_writer():

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -1,12 +1,16 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo
+from utils.navigation import render_sidebar, SMALL_LOGO_HTML
 
 
-st.set_page_config(layout="centered", initial_sidebar_state="expanded")
+st.set_page_config(
+    layout="centered",
+    initial_sidebar_state="expanded",
+    page_title="ResponseCreate",
+    page_icon=None,
+)
 render_sidebar()
-render_logo()
-st.title("📧 ResponseCreate")
+st.markdown(f"<h1>{SMALL_LOGO_HTML} ResponseCreate</h1>", unsafe_allow_html=True)
 
 
 def render_constituent_response():

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -1,13 +1,17 @@
 import streamlit as st
 from pathlib import Path
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo
+from utils.navigation import render_sidebar, SMALL_LOGO_HTML
 
 
-st.set_page_config(layout="centered", initial_sidebar_state="expanded")
+st.set_page_config(
+    layout="centered",
+    initial_sidebar_state="expanded",
+    page_title="LegTrack",
+    page_icon=None,
+)
 render_sidebar()
-render_logo()
-st.title("🔍 LegTrack")
+st.markdown(f"<h1>{SMALL_LOGO_HTML} LegTrack</h1>", unsafe_allow_html=True)
 
 
 def render_knowledge_center():

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -1,11 +1,15 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo
+from utils.navigation import render_sidebar, SMALL_LOGO_HTML
 
-st.set_page_config(layout="centered", initial_sidebar_state="expanded")
+st.set_page_config(
+    layout="centered",
+    initial_sidebar_state="expanded",
+    page_title="MailCreate",
+    page_icon=None,
+)
 render_sidebar()
-render_logo()
-st.title("✉️ MailCreate")
+st.markdown(f"<h1>{SMALL_LOGO_HTML} MailCreate</h1>", unsafe_allow_html=True)
 
 
 def render_mail_creator():

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -2,6 +2,17 @@ import streamlit as st
 from pathlib import Path
 import base64
 
+# Preload the application logo for reuse
+_logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
+with open(_logo_path, "rb") as _f:
+    _encoded_logo = base64.b64encode(_f.read()).decode()
+
+# Small inline logo HTML used in page headers
+SMALL_LOGO_HTML = (
+    f"<img src='data:image/png;base64,{_encoded_logo}' width='20' "
+    "style='vertical-align:middle;margin-right:4px;'>"
+)
+
 
 def render_sidebar(on_certcreate=None):
     st.markdown(
@@ -9,15 +20,15 @@ def render_sidebar(on_certcreate=None):
         unsafe_allow_html=True,
     )
     with st.sidebar:
-        st.page_link("app.py", label="LegAid")
+        st.page_link("app.py", label="LegAid", icon=None)
         if on_certcreate:
             st.button("CertCreate", on_click=on_certcreate)
         else:
-            st.page_link("pages/1_CertCreate.py", label="CertCreate")
-        st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate")
-        st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
-        st.page_link("pages/4_LegTrack.py", label="LegTrack")
-        st.page_link("pages/5_MailCreate.py", label="MailCreate")
+            st.page_link("pages/1_CertCreate.py", label="CertCreate", icon=None)
+        st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate", icon=None)
+        st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate", icon=None)
+        st.page_link("pages/4_LegTrack.py", label="LegTrack", icon=None)
+        st.page_link("pages/5_MailCreate.py", label="MailCreate", icon=None)
 
 
 def render_logo():

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ openpyxl
 pillow
 pytesseract
 reportlab
+docx2txt


### PR DESCRIPTION
## Summary
- show small logo only in page headers
- set page titles to keep navigation text clean
- explicitly disable icons on main page links and sidebar

## Testing
- `python -m py_compile LegAid/app.py LegAid/pages/1_CertCreate.py LegAid/pages/2_SpeechCreate.py LegAid/pages/3_ResponseCreate.py LegAid/pages/4_LegTrack.py LegAid/pages/5_MailCreate.py LegAid/utils/navigation.py`

------
https://chatgpt.com/codex/tasks/task_e_685343190684832cb92f4c3854896b4b