### PR TITLE
Remove small logos

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -14,7 +14,6 @@ render_sidebar()
 logo_path = Path(__file__).parent / "Assets" / "MainLogo.png"
 with open(logo_path, "rb") as f:
     encoded = base64.b64encode(f.read()).decode()
-logo_small = f"<img src='data:image/png;base64,{encoded}' width='20' style='vertical-align:middle;margin-right:4px;'>"
 
 st.markdown(
     f"""
@@ -39,17 +38,12 @@ st.markdown(
 
 col1, col2, col3, col4, col5 = st.columns(5)
 with col1:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/1_CertCreate.py", label="CertCreate")
 with col2:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate")
 with col3:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
 with col4:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/4_LegTrack.py", label="LegTrack")
 with col5:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/5_MailCreate.py", label="MailCreate")

--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import re
 from dateutil import parser as date_parser
 from pathlib import Path
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 from pdfminer.high_level import extract_text
 import openai
 from docx import Document
@@ -550,7 +550,7 @@ def split_certificate(index):
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar(on_certcreate=reset_request)
 render_logo()
-st.markdown(f"<h1>{SMALL_LOGO_HTML} CertCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>CertCreate</h1>", unsafe_allow_html=True)
 
 st.markdown(
     """

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -1,12 +1,12 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.markdown(f"<h1>{SMALL_LOGO_HTML} SpeechCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>SpeechCreate</h1>", unsafe_allow_html=True)
 
 
 def render_speech_writer():

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -1,12 +1,12 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.markdown(f"<h1>{SMALL_LOGO_HTML} ResponseCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>ResponseCreate</h1>", unsafe_allow_html=True)
 
 
 def render_constituent_response():

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -1,13 +1,13 @@
 import streamlit as st
 from pathlib import Path
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.markdown(f"<h1>{SMALL_LOGO_HTML} LegTrack</h1>", unsafe_allow_html=True)
+st.markdown("<h1>LegTrack</h1>", unsafe_allow_html=True)
 
 
 def render_knowledge_center():

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -1,11 +1,11 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(layout="centered", initial_sidebar_state="expanded")
 render_sidebar()
 render_logo()
-st.markdown(f"<h1>{SMALL_LOGO_HTML} MailCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>MailCreate</h1>", unsafe_allow_html=True)
 
 
 def render_mail_creator():

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -2,41 +2,21 @@ import streamlit as st
 from pathlib import Path
 import base64
 
-# Preload the application logo for reuse
-_logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
-with open(_logo_path, "rb") as _f:
-    _encoded_logo = base64.b64encode(_f.read()).decode()
-
-# Small inline logo HTML used in page headers
-SMALL_LOGO_HTML = (
-    f"<img src='data:image/png;base64,{_encoded_logo}' width='20' "
-    "style='vertical-align:middle;margin-right:4px;'>"
-)
-
 
 def render_sidebar(on_certcreate=None):
     st.markdown(
         "<style>[data-testid='stSidebarNav']{display:none;}</style>",
         unsafe_allow_html=True,
     )
-    logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
-    with open(logo_path, "rb") as f:
-        encoded = base64.b64encode(f.read()).decode()
-    logo_small = f"<img src='data:image/png;base64,{encoded}' width='20' style='vertical-align:middle;margin-right:4px;'>"
     with st.sidebar:
         st.page_link("app.py", label="LegAid")
         if on_certcreate:
             st.button("CertCreate", on_click=on_certcreate)
         else:
-            st.markdown(logo_small, unsafe_allow_html=True)
             st.page_link("pages/1_CertCreate.py", label="CertCreate")
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate")
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate")
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/4_LegTrack.py", label="LegTrack")
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/5_MailCreate.py", label="MailCreate")
 
 


### PR DESCRIPTION
## Summary
- remove SMALL_LOGO_HTML constant and sidebar icons
- drop small logos from page headers
- simplify landing page navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68536047d3ec832c8ec026bfaec9225c