### PR TITLE
Remove small logos

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -14,7 +14,6 @@ render_sidebar()
 logo_path = Path(__file__).parent / "Assets" / "MainLogo.png"
 with open(logo_path, "rb") as f:
     encoded = base64.b64encode(f.read()).decode()
-logo_small = f"<img src='data:image/png;base64,{encoded}' width='20' style='vertical-align:middle;margin-right:4px;'>"
 
 st.markdown(
     f"""
@@ -40,18 +39,13 @@ st.markdown(
 col1, col2, col3, col4, col5 = st.columns(5)
 
 with col1:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/1_CertCreate.py", label="CertCreate", icon=None)
 with col2:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate", icon=None)
 with col3:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate", icon=None)
 with col4:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/4_LegTrack.py", label="LegTrack", icon=None)
 with col5:
-    st.markdown(logo_small, unsafe_allow_html=True)
     st.page_link("pages/5_MailCreate.py", label="MailCreate", icon=None)
 

--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import re
 from dateutil import parser as date_parser
 from pathlib import Path
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 from pdfminer.high_level import extract_text
 import openai
 from docx import Document
@@ -555,7 +555,7 @@ st.set_page_config(
 )
 render_sidebar(on_certcreate=reset_request)
 render_logo()
-st.markdown(f"<h1>{SMALL_LOGO_HTML} CertCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>CertCreate</h1>", unsafe_allow_html=True)
 
 st.markdown(
     """

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 
 
@@ -13,7 +13,7 @@ st.set_page_config(
 render_sidebar()
 render_logo()
 
-st.markdown(f"<h1>{SMALL_LOGO_HTML} SpeechCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>SpeechCreate</h1>", unsafe_allow_html=True)
 
 
 def render_speech_writer():

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 
 
@@ -13,7 +13,7 @@ st.set_page_config(
 render_sidebar()
 render_logo()
 
-st.markdown(f"<h1>{SMALL_LOGO_HTML} ResponseCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>ResponseCreate</h1>", unsafe_allow_html=True)
 
 
 def render_constituent_response():

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from pathlib import Path
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 
 
@@ -14,7 +14,7 @@ st.set_page_config(
 render_sidebar()
 render_logo()
 
-st.markdown(f"<h1>{SMALL_LOGO_HTML} LegTrack</h1>", unsafe_allow_html=True)
+st.markdown("<h1>LegTrack</h1>", unsafe_allow_html=True)
 
 
 def render_knowledge_center():

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from utils.shared_functions import example_helper
-from utils.navigation import render_sidebar, render_logo, SMALL_LOGO_HTML
+from utils.navigation import render_sidebar, render_logo
 
 
 st.set_page_config(
@@ -12,7 +12,7 @@ st.set_page_config(
 render_sidebar()
 render_logo()
 
-st.markdown(f"<h1>{SMALL_LOGO_HTML} MailCreate</h1>", unsafe_allow_html=True)
+st.markdown("<h1>MailCreate</h1>", unsafe_allow_html=True)
 
 
 def render_mail_creator():

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -7,11 +7,6 @@ _logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
 with open(_logo_path, "rb") as _f:
     _encoded_logo = base64.b64encode(_f.read()).decode()
 
-# Small inline logo HTML used in page headers
-SMALL_LOGO_HTML = (
-    f"<img src='data:image/png;base64,{_encoded_logo}' width='20' "
-    "style='vertical-align:middle;margin-right:4px;'>"
-)
 
 
 def render_sidebar(on_certcreate=None):
@@ -22,25 +17,19 @@ def render_sidebar(on_certcreate=None):
     logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
     with open(logo_path, "rb") as f:
         encoded = base64.b64encode(f.read()).decode()
-    logo_small = f"<img src='data:image/png;base64,{encoded}' width='20' style='vertical-align:middle;margin-right:4px;'>"
     with st.sidebar:
         st.page_link("app.py", label="LegAid", icon=None)
         if on_certcreate:
             st.button("CertCreate", on_click=on_certcreate)
         else:
-            st.markdown(logo_small, unsafe_allow_html=True)
             st.page_link("pages/1_CertCreate.py", label="CertCreate", icon=None)
 
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate", icon=None)
 
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/3_ResponseCreate.py", label="ResponseCreate", icon=None)
 
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/4_LegTrack.py", label="LegTrack", icon=None)
 
-        st.markdown(logo_small, unsafe_allow_html=True)
         st.page_link("pages/5_MailCreate.py", label="MailCreate", icon=None)
 
 


### PR DESCRIPTION
## Summary
- strip out the small logo from the sidebar and pages
- drop `SMALL_LOGO_HTML` constant
- clean up page headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853635be594832c85054841b18db156