### PR TITLE
Fix CertCreate reset

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -554,7 +554,7 @@ st.set_page_config(
     page_title="CertCreate",
     page_icon=None,
 )
-render_sidebar(on_certcreate=reset_request)
+render_sidebar()
 render_logo()
 st.markdown("<h1>CertCreate</h1>", unsafe_allow_html=True)
 

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from pathlib import Path
 import base64
+from .shared_functions import reset_certcreate_session
 
 # Preload the application logo for reuse
 _logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
@@ -9,7 +10,7 @@ with open(_logo_path, "rb") as _f:
 
 
 
-def render_sidebar(on_certcreate=None):
+def render_sidebar():
     st.markdown(
         "<style>[data-testid='stSidebarNav']{display:none;}</style>",
         unsafe_allow_html=True,
@@ -19,9 +20,9 @@ def render_sidebar(on_certcreate=None):
         encoded = base64.b64encode(f.read()).decode()
     with st.sidebar:
         st.page_link("app.py", label="LegAid", icon=None)
-        st.page_link("pages/1_CertCreate.py", label="CertCreate", icon=None)
-        if on_certcreate:
-            st.button("Reset", on_click=on_certcreate)
+        if st.button("CertCreate", use_container_width=True):
+            reset_certcreate_session()
+            st.switch_page("pages/1_CertCreate.py")
 
         st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate", icon=None)
 

--- a/LegAid/utils/shared_functions.py
+++ b/LegAid/utils/shared_functions.py
@@ -4,3 +4,26 @@
 def example_helper():
     """Example helper function."""
     pass
+
+
+def reset_certcreate_session():
+    """Clear CertCreate-related session state keys."""
+    import streamlit as st
+
+    keys = [
+        "pdf_text",
+        "source_type",
+        "parsed_entries",
+        "cert_rows",
+        "uniform_template",
+        "event_date_raw",
+        "formatted_event_date",
+        "use_uniform",
+        "guidance",
+        "manual_certs",
+    ]
+    for k in keys:
+        if k in st.session_state:
+            del st.session_state[k]
+    st.session_state.started = False
+    st.session_state.start_mode = None


### PR DESCRIPTION
## Summary
- assign CertCreate sidebar link to clear session state
- move session reset logic to a shared helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537160fad0832c884e0f33d2c942b9