### PR TITLE
Fix CertCreate link style

### DIFF
--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -1,7 +1,6 @@
 import streamlit as st
 from pathlib import Path
 import base64
-from .shared_functions import reset_certcreate_session
 
 # Preload the application logo for reuse
 _logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
@@ -20,9 +19,11 @@ def render_sidebar():
         encoded = base64.b64encode(f.read()).decode()
     with st.sidebar:
         st.page_link("app.py", label="LegAid", icon=None)
-        if st.button("CertCreate", use_container_width=True):
-            reset_certcreate_session()
-            st.switch_page("pages/1_CertCreate.py")
+        st.page_link(
+            "pages/1_CertCreate.py",
+            label="CertCreate",
+            icon=None,
+        )
 
         st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate", icon=None)
 


### PR DESCRIPTION
## Summary
- make CertCreate a `page_link` like the other sidebar items

## Testing
- `python -m py_compile LegAid/utils/navigation.py LegAid/pages/1_CertCreate.py`


------
https://chatgpt.com/codex/tasks/task_e_6853789e28ec832c9af7578b0c7b968a