### PR TITLE
Fix paste request parsing bug

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -373,7 +373,14 @@ Return ONLY valid JSON.
             template_text = template_text.rstrip(" .") + " Wish you the best."
         parsed_entries = data.get("certificates", [])
     else:
-        parsed_entries = data
+        # handle both raw list and wrapped dict formats
+        if isinstance(data, dict) and "certificates" in data:
+            parsed_entries = data.get("certificates", [])
+        else:
+            parsed_entries = data
+
+    if not isinstance(parsed_entries, list):
+        raise ValueError("Parsed entries must be a list of certificates")
 
     for parsed in parsed_entries:
         name = parsed.get("name") or "Recipient"


### PR DESCRIPTION
## Summary
- handle dictionary-wrapped responses when parsing GPT output
- validate parsed entries as a list

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68538b4f6e58832cbaf3406b72a69a13