### PR TITLE
Improve certificate JSON handling

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -380,7 +380,11 @@ Return ONLY valid JSON.
             parsed_entries = data
 
     if not isinstance(parsed_entries, list):
-        raise ValueError("Parsed entries must be a list of certificates")
+        # Allow a single certificate dictionary by wrapping it in a list
+        if isinstance(parsed_entries, dict):
+            parsed_entries = [parsed_entries]
+        else:
+            raise ValueError("Parsed entries must be a list of certificates")
 
     for parsed in parsed_entries:
         name = parsed.get("name") or "Recipient"


### PR DESCRIPTION
## Summary
- let extract_certificates accept a single certificate dictionary

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68538f01f128832c9210b4736b776f0d