### PR TITLE
Rename regenerate option

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -858,7 +858,7 @@ global_comment = st.text_area(
     key="global_comment"
 )
 
-if st.button("🔄 Regenerate All Certificates", key="regen_all"):
+if st.button("🔄 Recreate All Certificates", key="regen_all"):
     cert_rows = apply_global_comment(cert_rows, global_comment)
     new_rows = []
     for cert in cert_rows:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The **Modify All** box can modify any certificate field. For example:
 - `Use organization instead of title` copies the organization value into the Title field for each certificate.
 - `Replace 'Officer' in title with organization` swaps the word "Officer" in every title with the certificate's organization.
 
-After entering a comment, click **Regenerate All Certificates** to apply the changes.
+After entering a comment, click **Recreate All Certificates** to apply the changes.
 
 ## 🏷️ Uniform Certificate Text
 


### PR DESCRIPTION
## Summary
- rename "Regenerate All Certificates" wording to "Recreate All Certificates" in UI and docs

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685395b3c90c832cb9d0eaf024eefc9d