### PR TITLE
Improve document text extraction

### DIFF
--- a/LegAid/requirements.txt
+++ b/LegAid/requirements.txt
@@ -8,3 +8,5 @@ openpyxl
 pillow
 pytesseract
 reportlab
+PyMuPDF
+striprtf

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # LegAid – Certificate Generator
 
 The certificate generator is now part of **LegAid**, a multi‑page Streamlit application.
-It still relies on `pdfminer.six` for stable PDF text extraction and supports text, Word, Excel,
-CSV and image uploads. Images are processed using OCR via Tesseract (ensure the
-`tesseract` binary is installed).
-Generated certificates can be downloaded as Word documents or as PDFs.
+It relies on `pdfminer.six` and `PyMuPDF` for PDF text extraction with an OCR fallback using Tesseract when needed. In addition to text, Word, Excel and image uploads, the tool also accepts RTF documents and more image formats.
+Uploaded images and scanned PDFs are processed with Tesseract OCR (ensure the `tesseract` binary is installed). Generated certificates can be downloaded as Word documents or as PDFs.
 
 Run the entire suite with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pillow
 pytesseract
 reportlab
 docx2txt
+PyMuPDF
+striprtf


### PR DESCRIPTION
## Summary
- support OCR fallback for scanned PDFs using PyMuPDF and Tesseract
- add RTF support and more image formats
- allow more file types in uploader
- document new capabilities in README
- list PyMuPDF and striprtf in requirements

## Testing
- `pytest -q`
- `ruff check LegAid/pages/1_CertCreate.py | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68539732d2f8832c887800c7e9290c9f