### PR TITLE
Fix start new request button

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -820,6 +820,7 @@ source_type = st.session_state.get("source_type", "pasted")
 if st.session_state.started:
     if st.button("🔄 Start New Request"):
         reset_request()
+        safe_rerun()
 
 # Attempt to auto-detect the event date from the text
 auto_date_raw = extract_event_date(pdf_text)


### PR DESCRIPTION
## Summary
- reload CertCreate page when 'Start New Request' is clicked

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853989fb228832c979255848fa58066