### PR TITLE
Fix certificate field expander

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -924,7 +924,11 @@ final_cert_rows = []
 for i, cert in enumerate(cert_rows, 1):
     display_title = format_display_title(cert['Title'], cert['Organization'])
     kwargs = {"expanded": True} if i-1 in expanded_indices else {}
-    with st.expander(f"📜 {cert['Name']} – {display_title}", **kwargs):
+    with st.expander(
+        f"📜 {cert['Name']} – {display_title}",
+        key=f"expander_{i}",
+        **kwargs,
+    ):
 
         if cert.get("possible_split"):
             st.warning("⚠️ This entry may include multiple recipients.")


### PR DESCRIPTION
## Summary
- keep certificate expander open when editing by giving it a stable key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a183aa98832ca071439f34c0fd2d