### PR TITLE
Fix expander key usage

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -926,7 +926,6 @@ for i, cert in enumerate(cert_rows, 1):
     kwargs = {"expanded": True} if i-1 in expanded_indices else {}
     with st.expander(
         f"📜 {cert['Name']} – {display_title}",
-        key=f"expander_{i}",
         **kwargs,
     ):
 


### PR DESCRIPTION
## Summary
- remove unsupported `key` argument from `st.expander`

## Testing
- `python3 -m py_compile LegAid/pages/1_CertCreate.py`

------
https://chatgpt.com/codex/tasks/task_e_6853a2e6a6e0832cbc73c536cb927591