### PR TITLE
Allow partial certificate entries

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -379,6 +379,8 @@ The event date is: {event_date}
 
 Name values must be no longer than {NAME_MAX_CHARS} characters including spaces. Title values must be no longer than {TITLE_MAX_CHARS} characters including spaces. Certificate text should be around {TEXT_MAX_CHARS} characters or fewer and at most {TEXT_MAX_LINES} lines.
 
+If some fields are missing, leave them blank rather than skipping the entry. We still want partial results.
+
 Return ONLY valid JSON.
 """
     else:
@@ -404,6 +406,8 @@ Each certificate must include:
 The event date is: {event_date}
 
 Name values must be no longer than {NAME_MAX_CHARS} characters including spaces. Title values must be no longer than {TITLE_MAX_CHARS} characters including spaces. Certificate text should be around {TEXT_MAX_CHARS} characters or fewer and at most {TEXT_MAX_LINES} lines.
+
+If some fields cannot be determined, leave them empty instead of omitting the certificate entirely.
 
 Return ONLY valid JSON.
 """

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ streamlit run LegAid/app.py
 
 When extracting certificate information, the app uses GPT to parse titles and organizations from event text. If an organization is hosting the event, its name should **not** be placed in the Title block for certificates associated with the host. Only include "Title of Organization" when an individual or group from that organization is being recognized by the host organization.
 
+If some details are missing from the text, the generator will now produce partial certificates with any fields it can infer. Blank values can be edited later in the interface.
+
 ## ✨ Modify All
 
 The **Modify All** box can modify any certificate field. For example:


### PR DESCRIPTION
## Summary
- allow partial certificate fields when extracting from event text
- mention partial certificate generation in README

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py flyer_ocr_parser.py learned_preferences_writer.py`

------
https://chatgpt.com/codex/tasks/task_e_6853ad2a62b8832cbc8a54307d189e94