### PR TITLE
Clean up unused imports and flake8 errors

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -1047,13 +1047,13 @@ for i, cert in enumerate(cert_rows, 1):
                 f"<div style='text-align:center; font-size:{int(date_size)}px; margin-top:{mt}px;'>{line}</div>"
             )
         lines.append(
-            f"<div style='text-align:right; font-size:12px; margin-top:0;'>_____________________________________</div>"
+            "<div style='text-align:right; font-size:12px; margin-top:0;'>_____________________________________</div>"
         )
         lines.append(
-            f"<div style='text-align:right; font-size:14px; margin-top:0;'>Stan Ellis</div>"
+            "<div style='text-align:right; font-size:14px; margin-top:0;'>Stan Ellis</div>"
         )
         lines.append(
-            f"<div style='text-align:right; font-size:14px; margin-top:0;'>Assemblyman, 32nd District</div>"
+            "<div style='text-align:right; font-size:14px; margin-top:0;'>Assemblyman, 32nd District</div>"
         )
         st.markdown("<br>".join(lines), unsafe_allow_html=True)
 

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from utils.shared_functions import example_helper
 from utils.navigation import render_sidebar, render_logo
 
 

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from utils.shared_functions import example_helper
 from utils.navigation import render_sidebar, render_logo
 
 

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -1,6 +1,4 @@
 import streamlit as st
-from pathlib import Path
-from utils.shared_functions import example_helper
 from utils.navigation import render_sidebar, render_logo
 
 

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from utils.shared_functions import example_helper
 from utils.navigation import render_sidebar, render_logo
 
 

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -14,9 +14,6 @@ def render_sidebar():
         "<style>[data-testid='stSidebarNav']{display:none;}</style>",
         unsafe_allow_html=True,
     )
-    logo_path = Path(__file__).resolve().parent.parent / "Assets" / "MainLogo.png"
-    with open(logo_path, "rb") as f:
-        encoded = base64.b64encode(f.read()).decode()
     with st.sidebar:
         st.page_link("app.py", label="LegAid", icon=None)
         st.page_link(

--- a/learned_preferences_writer.py
+++ b/learned_preferences_writer.py
@@ -1,5 +1,4 @@
 import json
-import re
 from collections import Counter
 from pathlib import Path
 
@@ -15,7 +14,6 @@ def summarize_logs(log_dir="logs", output_file="learned_preferences.json", top_n
         return
 
     endings = Counter()
-    structures = Counter()
     tone_notes = set()
 
     for log_file in log_path.glob("cert_logs_*.jsonl"):
@@ -25,7 +23,6 @@ def summarize_logs(log_dir="logs", output_file="learned_preferences.json", top_n
                     entry = json.loads(line)
                     if not entry.get("approved"): continue
                     final_text = entry.get("final_commendation", "").strip()
-                    original_text = entry.get("original_commendation", "").strip()
 
                     # Phrase frequency
                     phrases = extract_phrases(final_text)


### PR DESCRIPTION
## Summary
- remove unused imports in Streamlit pages
- drop unused variables in navigation and prefs writer
- fix invalid f-strings in CertCreate

## Testing
- `python -m compileall -q .`
- `flake8 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6853b74e78f8832c9e6181c4fc30f94a