### PR TITLE
Add OCR prerequisites checks and docs

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import os
 import json
+import shutil
 import tempfile
 from datetime import datetime
 import re
@@ -26,6 +27,18 @@ import random
 
 client = openai.OpenAI()
 OPENAI_MODEL = "gpt-4o"
+
+if not shutil.which("tesseract"):
+    st.error(
+        "Tesseract OCR is not installed or not found in PATH. Install `tesseract-ocr` to enable image uploads."
+    )
+    st.stop()
+
+if not os.getenv("OPENAI_API_KEY"):
+    st.error(
+        "OPENAI_API_KEY environment variable is not set. Add your key in Settings → Secrets to continue."
+    )
+    st.stop()
 
 # Font and text constraints
 NAME_MIN_SIZE = 24

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ The certificate generator is now part of **LegAid**, a multi‑page Streamlit ap
 It relies on `pdfminer.six` and `PyMuPDF` for PDF text extraction with an OCR fallback using Tesseract when needed. In addition to text, Word, Excel and image uploads, the tool also accepts RTF documents and more image formats.
 Uploaded images and scanned PDFs are processed with Tesseract OCR (ensure the `tesseract` binary is installed). Generated certificates can be downloaded as Word documents or as PDFs.
 
+## Prerequisites
+
+Image uploads rely on external tools:
+
+- **Tesseract OCR** – install the `tesseract` executable and make sure it is in your PATH. On Ubuntu/Debian you can install it with:
+
+  ```bash
+  sudo apt-get update && sudo apt-get install -y tesseract-ocr
+  ```
+
+- **OPENAI_API_KEY** – set this environment variable with your OpenAI API key so the app can parse text.
+
 Run the entire suite with:
 
 ```bash

--- a/flyer_ocr_parser.py
+++ b/flyer_ocr_parser.py
@@ -5,6 +5,17 @@ import sys
 from PIL import Image, ImageOps
 import pytesseract
 import openai
+import shutil
+
+if shutil.which("tesseract") is None:
+    raise RuntimeError(
+        "Tesseract OCR is required but was not found in PATH. Install `tesseract-ocr`."
+    )
+
+if not os.getenv("OPENAI_API_KEY"):
+    raise RuntimeError(
+        "OPENAI_API_KEY environment variable is not set. Provide your OpenAI API key to continue."
+    )
 
 SYSTEM_PROMPT = """You are an intelligent assistant built into the certificate generation app. A user uploads an event flyer or certificate request image. Analyze the flyer text to identify only real, explicitly named individuals or organizations. Do not create placeholder names or titles. If a host or sponsoring organization is clearly listed, produce a certificate entry for that organization. Skip certificates for event themes or generic phrases and use patriotic or formal language in each commendation.
 


### PR DESCRIPTION
## Summary
- add README section describing required Tesseract OCR and API key
- validate Tesseract and OPENAI_API_KEY in `1_CertCreate.py`
- validate the same prerequisites in `flyer_ocr_parser.py`

## Testing
- `python -m py_compile flyer_ocr_parser.py LegAid/pages/1_CertCreate.py`
- `pip install -r requirements.txt`
- `python flyer_ocr_parser.py --help` *(fails: Tesseract not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6853bb9e1040832c9c426567a2c602cf