### PR TITLE
Switch from Tesseract to Google Vision OCR

### DIFF
--- a/LegAid/requirements.txt
+++ b/LegAid/requirements.txt
@@ -6,7 +6,8 @@ python-docx
 python-dateutil
 openpyxl
 pillow
-pytesseract
+requests
+pdf2image
 reportlab
 PyMuPDF
 striprtf

--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
 # LegAid – Certificate Generator
 
 The certificate generator is now part of **LegAid**, a multi‑page Streamlit application.
-It relies on `pdfminer.six` and `PyMuPDF` for PDF text extraction with an OCR fallback using Tesseract when needed. In addition to text, Word, Excel and image uploads, the tool also accepts RTF documents and more image formats.
-Uploaded images and scanned PDFs are processed with Tesseract OCR (ensure the `tesseract` binary is installed). Generated certificates can be downloaded as Word documents or as PDFs.
+It relies on `pdfminer.six` and `PyMuPDF` for PDF text extraction with Google Vision OCR as a fallback. In addition to text, Word, Excel and image uploads, the tool also accepts RTF documents and more image formats.
+Uploaded images and scanned PDFs are processed through the Google Vision API so no system-level OCR installation is required. Generated certificates can be downloaded as Word documents or as PDFs.
 
 ## Prerequisites
 
-Image uploads rely on external tools:
+Image uploads rely on these secrets:
 
-- **Tesseract OCR** – install the `tesseract` executable and make sure it is in your PATH. On Ubuntu/Debian you can install it with:
-
-  ```bash
-  sudo apt-get update && sudo apt-get install -y tesseract-ocr
-  ```
-
+- **google_vision_key** – add this key to your Streamlit secrets for OCR.
 - **OPENAI_API_KEY** – set this environment variable with your OpenAI API key so the app can parse text.
 
 Run the entire suite with:
@@ -55,7 +50,7 @@ Enable the **Keep Certificate Text Uniformed** checkbox before generating certif
 
 ## 🖼️ Parsing Event Flyers
 
-Use `flyer_ocr_parser.py` to extract certificate fields directly from an event flyer or request image. Provide the path to the image and ensure `tesseract` is installed and the `OPENAI_API_KEY` environment variable is set:
+Use `flyer_ocr_parser.py` to extract certificate fields directly from an event flyer or request image. Provide the path to the image along with the `OPENAI_API_KEY` and `GOOGLE_VISION_KEY` environment variables:
 
 ```bash
 python flyer_ocr_parser.py path/to/flyer.png

--- a/flyer_ocr_parser.py
+++ b/flyer_ocr_parser.py
@@ -3,18 +3,20 @@ import json
 import argparse
 import sys
 from PIL import Image, ImageOps
-import pytesseract
+from io import BytesIO
+import base64
+import requests
 import openai
-import shutil
 
-if shutil.which("tesseract") is None:
-    raise RuntimeError(
-        "Tesseract OCR is required but was not found in PATH. Install `tesseract-ocr`."
-    )
 
 if not os.getenv("OPENAI_API_KEY"):
     raise RuntimeError(
         "OPENAI_API_KEY environment variable is not set. Provide your OpenAI API key to continue."
+    )
+
+if not os.getenv("GOOGLE_VISION_KEY"):
+    raise RuntimeError(
+        "GOOGLE_VISION_KEY environment variable is not set. Provide your Google Vision API key to continue."
     )
 
 SYSTEM_PROMPT = """You are an intelligent assistant built into the certificate generation app. A user uploads an event flyer or certificate request image. Analyze the flyer text to identify only real, explicitly named individuals or organizations. Do not create placeholder names or titles. If a host or sponsoring organization is clearly listed, produce a certificate entry for that organization. Skip certificates for event themes or generic phrases and use patriotic or formal language in each commendation.
@@ -22,55 +24,35 @@ SYSTEM_PROMPT = """You are an intelligent assistant built into the certificate g
 Return the result strictly as a JSON list of dictionaries. Each dictionary must contain: name, title, organization, date_raw, commendation. Include an optional partners list if multiple logos or partners are identified."""
 
 
-def ocr_image(path: str, conf_threshold: int = 10, line_gap: int = 25) -> str:
-    """Return cleaned OCR text from the given image path.
+def ocr_image(path: str) -> str:
+    """Return OCR text from the given image path using Google Vision API."""
 
-    The function uses ``pytesseract.image_to_data`` to obtain layout
-    information. Words with a confidence score below ``conf_threshold`` are
-    discarded. Remaining words are grouped into lines if they are within
-    ``line_gap`` pixels vertically and then sorted from left to right.
-    """
+    key = os.getenv("GOOGLE_VISION_KEY")
+    if not key:
+        raise RuntimeError("GOOGLE_VISION_KEY environment variable is not set.")
 
-    img = ImageOps.exif_transpose(Image.open(path).convert("L"))
+    img = ImageOps.exif_transpose(Image.open(path))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
 
-    data = pytesseract.image_to_data(img, output_type=pytesseract.Output.DICT)
+    payload = {
+        "requests": [
+            {
+                "image": {"content": base64.b64encode(buf.getvalue()).decode()},
+                "features": [{"type": "DOCUMENT_TEXT_DETECTION"}],
+            }
+        ]
+    }
 
-    words = []
-    for text, conf, left, top in zip(
-        data["text"], data["conf"], data["left"], data["top"]
-    ):
-        text = text.strip()
-        try:
-            conf = int(conf)
-        except ValueError:
-            conf = 0
-        if text and conf > conf_threshold:
-            words.append({"text": text, "left": left, "top": top})
-
-    if not words:
-        return ""
-
-    words.sort(key=lambda w: (w["top"], w["left"]))
-    lines = []
-    current_line = []
-    current_top = words[0]["top"]
-
-    for word in words:
-        if abs(word["top"] - current_top) <= line_gap:
-            current_line.append(word)
-        else:
-            lines.append(
-                " ".join(w["text"] for w in sorted(current_line, key=lambda x: x["left"]))
-            )
-            current_line = [word]
-            current_top = word["top"]
-
-    if current_line:
-        lines.append(
-            " ".join(w["text"] for w in sorted(current_line, key=lambda x: x["left"]))
-        )
-
-    return "\n".join(lines)
+    resp = requests.post(
+        "https://vision.googleapis.com/v1/images:annotate",
+        params={"key": key},
+        json=payload,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["responses"][0].get("fullTextAnnotation", {}).get("text", "")
 
 
 def parse_certificate(text: str) -> list:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ python-docx
 python-dateutil
 openpyxl
 pillow
-pytesseract
+requests
+pdf2image
 reportlab
 docx2txt
 PyMuPDF


### PR DESCRIPTION
## Summary
- replace Tesseract-based OCR with Google Vision API
- drop pytesseract from requirements and add pdf2image/requests
- update flyer OCR parser to use Google Vision
- update documentation for Vision API workflow

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py flyer_ocr_parser.py learned_preferences_writer.py LegAid/utils/shared_functions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542605aa60832c83f7e8e65fd1d872