### PR TITLE
Normalize date strings before GPT parsing

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -7,6 +7,7 @@ import re
 from dateutil import parser as date_parser
 from pathlib import Path
 from utils.navigation import render_sidebar, render_logo
+from utils.shared_functions import normalize_date_strings
 from pdfminer.high_level import extract_text
 import openai
 from docx import Document
@@ -445,6 +446,9 @@ def extract_certificates(event_text, event_date, uniform=False):
     cert_rows = []
     parsed_entries = []
     template_text = ""
+
+    # Normalize any date strings in the OCR text before sending to GPT
+    event_text = normalize_date_strings(event_text)
 
     flyer_note = ""
     if st.session_state.get("source_type") == "flyer":

--- a/flyer_ocr_parser.py
+++ b/flyer_ocr_parser.py
@@ -8,6 +8,8 @@ import base64
 import requests
 import openai
 
+from LegAid.utils.shared_functions import normalize_date_strings
+
 
 if not os.getenv("OPENAI_API_KEY"):
     raise RuntimeError(
@@ -57,6 +59,8 @@ def ocr_image(path: str) -> str:
 
 def parse_certificate(text: str) -> list:
     """Call the OpenAI API to parse certificate data from text and return a list of certificate dictionaries."""
+
+    text = normalize_date_strings(text)
     client = openai.OpenAI()
     response = client.chat.completions.create(
         model="gpt-4o",


### PR DESCRIPTION
## Summary
- add utility to normalize common date formats
- preprocess OCR text before GPT use in CertCreate
- normalize flyer OCR text before parsing

## Testing
- `python3 -m py_compile LegAid/utils/shared_functions.py LegAid/pages/1_CertCreate.py flyer_ocr_parser.py`
- `python -m pip check`

------
https://chatgpt.com/codex/tasks/task_e_6854364da588832c8db71072ac1c8421