### PR TITLE
Improve sidebar UX

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -7,7 +7,7 @@ st.set_page_config(
     page_title="Legislative Tools",
     page_icon="📜",
     layout="wide",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="collapsed",
 )
 render_sidebar()
 

--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -84,6 +84,9 @@ def reset_request():
     st.session_state.started = False
     st.session_state.start_mode = None
 
+if st.session_state.pop("certcreate_reset", False):
+    reset_request()
+
 def vision_ocr_image(image_bytes: bytes) -> str:
     """Return OCR text from image bytes using Google Vision API."""
     key = st.secrets.get("google_vision_key")
@@ -710,7 +713,7 @@ def split_certificate(index):
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="expanded",
     page_title="CertCreate",
     page_icon=None,
 )

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="expanded",
     page_title="SpeechCreate",
     page_icon=None,
 )

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="expanded",
     page_title="ResponseCreate",
     page_icon=None,
 )

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="expanded",
     page_title="LegTrack",
     page_icon=None,
 )

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -4,7 +4,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="expanded",
     page_title="MailCreate",
     page_icon=None,
 )

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -10,17 +10,35 @@ with open(_logo_path, "rb") as _f:
 
 
 def render_sidebar():
+    """Render sidebar with mobile auto-close and navigation links."""
     st.markdown(
         "<style>[data-testid='stSidebarNav']{display:none;}</style>",
         unsafe_allow_html=True,
     )
+
+    # JavaScript to collapse the sidebar on small screens after a page load
+    st.markdown(
+        """
+        <script>
+        function closeSidebarIfMobile() {
+            const btn = window.parent.document.querySelector('button[title="Hide sidebar"]');
+            const sidebar = window.parent.document.querySelector('section[data-testid="stSidebar"]');
+            if (window.innerWidth <= 768 && btn && sidebar?.getAttribute('aria-expanded') === 'true') {
+                btn.click();
+            }
+        }
+        window.addEventListener('load', closeSidebarIfMobile);
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
+
     with st.sidebar:
         st.page_link("app.py", label="LegAid", icon=None)
-        st.page_link(
-            "pages/1_CertCreate.py",
-            label="CertCreate",
-            icon=None,
-        )
+
+        if st.button("CertCreate", key="nav_certcreate"):
+            st.session_state["certcreate_reset"] = True
+            st.switch_page("pages/1_CertCreate.py")
 
         st.page_link("pages/2_SpeechCreate.py", label="SpeechCreate", icon=None)
 


### PR DESCRIPTION
## Summary
- close the sidebar on small screens using JavaScript
- default to collapsed sidebar on main page
- default to expanded sidebar on other pages
- reset CertCreate session when navigating from sidebar

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685447f3e7ac832cafce2d6fdb91d4b5