### PR TITLE
Improve sidebar behavior and style

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -713,7 +713,7 @@ def split_certificate(index):
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="expanded",
+    initial_sidebar_state="collapsed",
     page_title="CertCreate",
     page_icon=None,
 )

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="expanded",
+    initial_sidebar_state="collapsed",
     page_title="SpeechCreate",
     page_icon=None,
 )

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="expanded",
+    initial_sidebar_state="collapsed",
     page_title="ResponseCreate",
     page_icon=None,
 )

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="expanded",
+    initial_sidebar_state="collapsed",
     page_title="LegTrack",
     page_icon=None,
 )

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -4,7 +4,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="expanded",
+    initial_sidebar_state="collapsed",
     page_title="MailCreate",
     page_icon=None,
 )

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -16,7 +16,28 @@ def render_sidebar():
         unsafe_allow_html=True,
     )
 
-    # JavaScript to collapse the sidebar on small screens after a page load
+    # Style the navigation links and CertCreate button consistently
+    st.markdown(
+        """
+        <style>
+        a[data-testid="stPageLink"],
+        button#nav_certcreate {
+            display:inline-block;
+            padding:0.75rem 1.25rem;
+            margin:0 0.1rem;
+            background:#004cbd;
+            color:#fff !important;
+            border-radius:4px;
+            text-decoration:none;
+            font-weight:600;
+            border:none;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    # JavaScript to collapse the sidebar on small screens
     st.markdown(
         """
         <script>
@@ -28,6 +49,11 @@ def render_sidebar():
             }
         }
         window.addEventListener('load', closeSidebarIfMobile);
+        window.parent.document.addEventListener('click', function(e) {
+            if (e.target.closest('a[data-testid="stPageLink"], #nav_certcreate')) {
+                setTimeout(closeSidebarIfMobile, 0);
+            }
+        });
         </script>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- match `CertCreate` link style with page links
- auto-collapse sidebar on mobile after selecting any link
- set sidebar collapsed by default across all pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544b19fb54832c9ef913ddda349de1