### PR TITLE
Auto collapse sidebar on mobile

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -7,7 +7,7 @@ st.set_page_config(
     page_title="Legislative Tools",
     page_icon="📜",
     layout="wide",
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="auto",
 )
 render_sidebar()
 

--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -713,7 +713,7 @@ def split_certificate(index):
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="auto",
     page_title="CertCreate",
     page_icon=None,
 )

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="auto",
     page_title="SpeechCreate",
     page_icon=None,
 )

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="auto",
     page_title="ResponseCreate",
     page_icon=None,
 )

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="auto",
     page_title="LegTrack",
     page_icon=None,
 )

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -4,7 +4,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="auto",
     page_title="MailCreate",
     page_icon=None,
 )

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -54,6 +54,8 @@ def render_sidebar():
                 setTimeout(closeSidebarIfMobile, 0);
             }
         });
+        // Immediately check on script load in case the load event already fired
+        closeSidebarIfMobile();
         </script>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- auto-close the sidebar when scripts load
- keep sidebars expanded on wider screens using `initial_sidebar_state="auto"`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_68544ce50118832c9869cccd68216113