### PR TITLE
Collapse sidebar on mobile

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -7,7 +7,7 @@ st.set_page_config(
     page_title="Legislative Tools",
     page_icon="📜",
     layout="wide",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="collapsed",
 )
 render_sidebar()
 

--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -713,7 +713,7 @@ def split_certificate(index):
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="collapsed",
     page_title="CertCreate",
     page_icon=None,
 )

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="collapsed",
     page_title="SpeechCreate",
     page_icon=None,
 )

--- a/LegAid/pages/3_ResponseCreate.py
+++ b/LegAid/pages/3_ResponseCreate.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="collapsed",
     page_title="ResponseCreate",
     page_icon=None,
 )

--- a/LegAid/pages/4_LegTrack.py
+++ b/LegAid/pages/4_LegTrack.py
@@ -5,7 +5,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="collapsed",
     page_title="LegTrack",
     page_icon=None,
 )

--- a/LegAid/pages/5_MailCreate.py
+++ b/LegAid/pages/5_MailCreate.py
@@ -4,7 +4,7 @@ from utils.navigation import render_sidebar, render_logo
 
 st.set_page_config(
     layout="centered",
-    initial_sidebar_state="auto",
+    initial_sidebar_state="collapsed",
     page_title="MailCreate",
     page_icon=None,
 )

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -38,25 +38,28 @@ def render_sidebar():
         unsafe_allow_html=True,
     )
 
-    # JavaScript to collapse the sidebar on small screens
+    # JavaScript to toggle the sidebar based on screen width
     st.markdown(
         """
         <script>
-        function closeSidebarIfMobile() {
-            const btn = window.parent.document.querySelector('button[title="Hide sidebar"]');
+        function adjustSidebar() {
+            const hideBtn = window.parent.document.querySelector('button[title="Hide sidebar"]');
+            const showBtn = window.parent.document.querySelector('button[title="Show sidebar"]');
             const sidebar = window.parent.document.querySelector('section[data-testid="stSidebar"]');
-            if (window.innerWidth <= 768 && btn && sidebar?.getAttribute('aria-expanded') === 'true') {
-                btn.click();
+            const expanded = sidebar?.getAttribute('aria-expanded');
+            if (window.innerWidth <= 768 && expanded === 'true' && hideBtn) {
+                hideBtn.click();
+            } else if (window.innerWidth > 768 && expanded === 'false' && showBtn) {
+                showBtn.click();
             }
         }
-        window.addEventListener('load', closeSidebarIfMobile);
+        window.addEventListener('load', adjustSidebar);
         window.parent.document.addEventListener('click', function(e) {
             if (e.target.closest('a[data-testid="stPageLink"], #nav_certcreate')) {
-                setTimeout(closeSidebarIfMobile, 0);
+                setTimeout(adjustSidebar, 0);
             }
         });
-        // Immediately check on script load in case the load event already fired
-        closeSidebarIfMobile();
+        adjustSidebar();
         </script>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- close sidebar by default on all pages
- auto-toggle sidebar open/closed with screen width

## Testing
- `python -m py_compile LegAid/utils/navigation.py LegAid/app.py LegAid/pages/1_CertCreate.py LegAid/pages/2_SpeechCreate.py LegAid/pages/3_ResponseCreate.py LegAid/pages/4_LegTrack.py LegAid/pages/5_MailCreate.py`

------
https://chatgpt.com/codex/tasks/task_e_6854531c0db8832ca7a530e533afafe1