### PR TITLE
Fix variable initialization in PDF generator

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -1343,11 +1343,11 @@ def generate_pdf_certificates(entries):
             for line in wrap_text(display_title, "Times-Bold", title_size, avail_width):
                 c.drawCentredString(center_x, y, line)
                 y -= title_size * 1.2
-           
-        if title_provided:
-            text_start_y = y
-            c.setFont("Times-Roman", text_size)
-            y = text_start_y - 0.0 * inch
+            if title_provided:
+                text_start_y = y
+
+        c.setFont("Times-Roman", text_size)
+        y = text_start_y
         for line in wrap_text(entry["Certificate_Text"], "Times-Roman", text_size, avail_width):
             c.drawCentredString(center_x, y, line)
             y -= text_size * 1.2


### PR DESCRIPTION
## Summary
- ensure `y` is defined when creating PDFs

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854569ea5f0832c8ddb2838a47b620f