### PR TITLE
Fix pronoun usage in generated certificates

### DIFF
--- a/LegAid/utils/shared_functions.py
+++ b/LegAid/utils/shared_functions.py
@@ -67,3 +67,21 @@ def reset_certcreate_session():
             del st.session_state[k]
     st.session_state.started = False
     st.session_state.start_mode = None
+
+
+def enforce_first_person(text: str) -> str:
+    """Return text with first-person pronouns instead of plural forms."""
+
+    replacements = [
+        (r"\bwe are\b", "I am"),
+        (r"\bwe're\b", "I'm"),
+        (r"\bwe have\b", "I have"),
+        (r"\bwe've\b", "I've"),
+        (r"\bwe\b", "I"),
+        (r"\bour\b", "my"),
+        (r"\bours\b", "mine"),
+    ]
+
+    for pattern, repl in replacements:
+        text = re.sub(pattern, repl, flags=re.IGNORECASE)
+    return text


### PR DESCRIPTION
## Summary
- add `enforce_first_person` helper to convert plural pronouns to singular
- ensure certificate text always goes through `enforce_first_person`
- apply the helper during extraction, regeneration, manual creation and bulk edits

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python flyer_ocr_parser.py --help` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_6854593fa9ac832cbe86141807137a79