### PR TITLE
Fix missing argument in enforce_first_person

### DIFF
--- a/LegAid/utils/shared_functions.py
+++ b/LegAid/utils/shared_functions.py
@@ -83,5 +83,5 @@ def enforce_first_person(text: str) -> str:
     ]
 
     for pattern, repl in replacements:
-        text = re.sub(pattern, repl, flags=re.IGNORECASE)
+        text = re.sub(pattern, repl, text, flags=re.IGNORECASE)
     return text


### PR DESCRIPTION
## Summary
- add missing `text` argument when calling `re.sub`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68545bd6f5a4832cbbacf5764d814601