### PR TITLE
Improve certificate openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ When extracting certificate information, the app uses GPT to parse titles and or
 
 If some details are missing from the text, the generator will now produce partial certificates with any fields it can infer. Blank values can be edited later in the interface.
 
+The opening line after "On behalf of the California State Legislature," now changes automatically based on the certificate's category—for example using "congratulations on," "honoring," or "celebrating"—to keep the tone appropriate.
+
 ## ✨ Modify All
 
 The **Modify All** box can modify any certificate field. For example:


### PR DESCRIPTION
## Summary
- vary the certificate opening phrase based on category
- clarify first-person customization features in the README

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py LegAid/utils/shared_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_685479f25694832c991feaa8e4ddd361