### PR TITLE
Improve certificate openings

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -486,6 +486,8 @@ Return JSON with two keys:
   template: a commendation using placeholders {{name}}, {{title}}, and {{organization}}
   certificates: list of certificates each with name, title, organization (if applicable), date_raw, category, optional possible_split and alternatives
 
+Each commendation must begin with "On behalf of the California State Legislature, {{opening}}" where {{opening}} is a brief phrase like "congratulations on", "honoring", or "celebrating" selected according to the certificate's category.
+
 The event date is: {event_date}
 
 Name values must be no longer than {NAME_MAX_CHARS} characters including spaces. Title values must be no longer than {TITLE_MAX_CHARS} characters including spaces. Certificate text should be around {TEXT_MAX_CHARS} characters or fewer and at most {TEXT_MAX_LINES} lines.
@@ -510,7 +512,7 @@ Each certificate must include:
 - organization (if applicable)
 - date_raw (or fallback to event date)
 - category: short (2–3 word) description of the recognition type
-- commendation: 2–3 sentence message starting with "On behalf of the California State Legislature..." that honors their work and ends with well wishes
+- commendation: 2–3 sentence message that honors their work and ends with well wishes. Start each commendation with "On behalf of the California State Legislature, {{opening}}" where {{opening}} is a brief phrase like "congratulations on", "honoring", or "celebrating" chosen according to the certificate's category.
 - optional: possible_split (true/false)
 - optional: alternatives (dictionary)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When extracting certificate information, the app uses GPT to parse titles and or
 
 If some details are missing from the text, the generator will now produce partial certificates with any fields it can infer. Blank values can be edited later in the interface.
 
-The opening line after "On behalf of the California State Legislature," now changes automatically based on the certificate's category—for example using "congratulations on," "honoring," or "celebrating"—to keep the tone appropriate.
+Every commendation now begins with "On behalf of the California State Legislature, {opening}" where the opening phrase—such as "congratulations on," "honoring," or "celebrating"—is chosen based on the certificate's category.
 
 ## ✨ Modify All
 


### PR DESCRIPTION
## Summary
- clarify in README that certificate openings match each category
- instruct GPT to start each commendation with a category-based phrase

## Testing
- `python -m py_compile LegAid/pages/1_CertCreate.py`
- `python -m py_compile flyer_ocr_parser.py`
- `python -m py_compile learned_preferences_writer.py`
- `python -m py_compile LegAid/utils/navigation.py`
- `python -m py_compile LegAid/utils/shared_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_68547cef9b1c832ca3d7f301b9895e4c