### PR TITLE
Add Next-Gen Research Assistant

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -37,7 +37,7 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-col1, col2, col3, col4, col5 = st.columns(5)
+col1, col2, col3, col4, col5, col6 = st.columns(6)
 
 with col1:
     st.page_link("pages/1_CertCreate.py", label="CertCreate", icon=None)
@@ -49,4 +49,6 @@ with col4:
     st.page_link("pages/4_LegTrack.py", label="LegTrack", icon=None)
 with col5:
     st.page_link("pages/5_MailCreate.py", label="MailCreate", icon=None)
+with col6:
+    st.page_link("pages/6_ResearchAssistant.py", label="Research Assistant", icon=None)
 

--- a/LegAid/pages/6_ResearchAssistant.py
+++ b/LegAid/pages/6_ResearchAssistant.py
@@ -1,0 +1,31 @@
+import streamlit as st
+import asyncio
+import os
+from utils.navigation import render_sidebar, render_logo
+from modules.research_assistant import build_your_assistant
+from modules.report_view import generate_html_report
+
+st.set_page_config(page_title="Research Assistant", layout="wide")
+render_sidebar()
+render_logo()
+
+# Load API keys from secrets into environment variables
+if "OPENAI_API_KEY" in st.secrets:
+    os.environ["OPENAI_API_KEY"] = st.secrets["OPENAI_API_KEY"]
+if "SERPAPI_API_KEY" in st.secrets:
+    os.environ["SERPAPI_API_KEY"] = st.secrets["SERPAPI_API_KEY"]
+if "TWITTER_BEARER_TOKEN" in st.secrets:
+    os.environ["TWITTER_BEARER_TOKEN"] = st.secrets["TWITTER_BEARER_TOKEN"]
+
+st.title("\ud83d\udd0d Next-Gen Research Assistant")
+
+query = st.text_input("Enter your research question")
+
+if st.button("Run Research") and query:
+    with st.spinner("Researching, analyzing, and synthesizing..."):
+        assistant = build_your_assistant()
+        result = asyncio.run(assistant.run(query))
+        st.success("Research complete.")
+        st.components.v1.html(generate_html_report(result), height=700, scrolling=True)
+        with st.expander("\ud83d\udd0e View Answer Text"):
+            st.write(result["answer"])

--- a/LegAid/requirements.txt
+++ b/LegAid/requirements.txt
@@ -11,3 +11,13 @@ pdf2image
 reportlab
 PyMuPDF
 striprtf
+httpx
+pydantic
+trafilatura
+faiss-cpu
+numpy
+fastapi
+uvicorn
+tweepy
+aiofiles
+python-dotenv

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -80,6 +80,8 @@ def render_sidebar():
 
         st.page_link("pages/5_MailCreate.py", label="MailCreate", icon=None)
 
+        st.page_link("pages/6_ResearchAssistant.py", label="Research Assistant", icon=None)
+
 
 
 def render_logo():

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Sequence, Dict, Any
+from pydantic import BaseModel, Field, validator
+
+@dataclass
+class LoopConfig:
+    max_loops: int = 3
+    confidence_threshold: float = 0.85
+    whitelist_domains: Sequence[str] | None = None  # e.g., (".gov", ".edu")
+    blacklist_domains: Sequence[str] | None = None
+    enable_hallucination_guard: bool = True
+    llm_model: str = "gpt-4o-mini"
+    llm_temperature: float = 0.2
+    request_timeout: float = 30.0  # seconds
+
+class SourceDoc(BaseModel):
+    source: str
+    title: str
+    url: str
+    content: str
+
+    @validator("content")
+    def truncate_content(cls, v: str):
+        # Truncate content to avoid excessive length (token limits)
+        return v[:15000]
+
+class SocialDoc(BaseModel):
+    platform: str
+    author: str
+    created_at: str
+    content: str
+    metrics: Dict[str, Any] = Field(default_factory=dict)

--- a/modules/extractors.py
+++ b/modules/extractors.py
@@ -1,0 +1,8 @@
+import asyncio
+import trafilatura
+
+class TrafilaturaExtractor:
+    """Web content extractor using Trafilatura."""
+    async def extract(self, url: str) -> str:
+        downloaded = await asyncio.to_thread(trafilatura.fetch_url, url)
+        return trafilatura.extract(downloaded, output_format="txt") or ""

--- a/modules/faiss_index.py
+++ b/modules/faiss_index.py
@@ -1,0 +1,46 @@
+import os
+import pickle
+import numpy as np
+import openai
+import faiss
+
+class SemanticMemory:
+    """Persistent FAISS-based vector store for semantic recall."""
+    def __init__(self, index_path: str = "faiss_index.bin", metadata_path: str = "index_meta.pkl"):
+        self.index_path = index_path
+        self.metadata_path = metadata_path
+        self.index = None
+        self.metadata = []
+        self.load()
+
+    def load(self):
+        if os.path.exists(self.index_path):
+            # Load existing FAISS index and metadata
+            self.index = faiss.read_index(self.index_path)
+            with open(self.metadata_path, "rb") as f:
+                self.metadata = pickle.load(f)
+        else:
+            # Initialize a new index (1536-dim for OpenAI embeddings)
+            self.index = faiss.IndexFlatL2(1536)
+            self.metadata = []
+
+    def save(self):
+        faiss.write_index(self.index, self.index_path)
+        with open(self.metadata_path, "wb") as f:
+            pickle.dump(self.metadata, f)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        response = openai.Embedding.create(input=texts, model="text-embedding-3-large")
+        return [item["embedding"] for item in response["data"]]
+
+    def add(self, texts: list[str], tags: list[str]):
+        vectors = self.embed(texts)
+        self.index.add(np.array(vectors).astype("float32"))
+        self.metadata.extend(tags)
+        self.save()
+
+    def search(self, query: str, top_k: int = 5) -> list[tuple[str, float]]:
+        query_vec = self.embed([query])[0]
+        D, I = self.index.search(np.array([query_vec]).astype("float32"), top_k)
+        return [(self.metadata[i], float(D[0][j])) for j, i in enumerate(I[0])]

--- a/modules/llm_engines.py
+++ b/modules/llm_engines.py
@@ -1,0 +1,20 @@
+import os
+import openai
+from typing import List, Dict
+
+class OpenAIEngine:
+    """Async OpenAI LLM wrapper for chat completion."""
+    def __init__(self, model: str, temperature: float, timeout: float):
+        self.model = model
+        self.temperature = temperature
+        self.timeout = timeout
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+
+    async def chat(self, messages: List[Dict[str, str]]) -> str:
+        response = await openai.ChatCompletion.acreate(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+            timeout=self.timeout
+        )
+        return response.choices[0].message.content.strip()

--- a/modules/loop_memory.py
+++ b/modules/loop_memory.py
@@ -1,0 +1,23 @@
+import json
+from typing import List
+
+class LoopMemory:
+    """Simple persistent log for recording each run (query and confidence)."""
+    def __init__(self, path: str = "loop_log.json"):
+        self.path = path
+        self.log: List[dict] = []
+
+    def append(self, entry: dict):
+        self.log.append(entry)
+        self.save()
+
+    def save(self):
+        with open(self.path, "w") as f:
+            json.dump(self.log, f, indent=2)
+
+    def load(self) -> List[dict]:
+        try:
+            with open(self.path, "r") as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return []

--- a/modules/report_view.py
+++ b/modules/report_view.py
@@ -1,0 +1,33 @@
+def generate_html_report(data: dict) -> str:
+    """Generate an HTML report string given the assistant result data."""
+    answer = f"<h2>Final Answer</h2><p>{data['answer']}</p>"
+    sources = "<h3>Sources</h3><ul>"
+    for src in data["sources"]:
+        title = src.get("title", "Untitled")
+        url = src.get("url", "#")
+        domain = src.get("source", "unknown")
+        sources += f"<li><a href='{url}' target='_blank'>{title}</a> – {domain}</li>"
+    sources += "</ul>"
+    log = "<h3>Loop Decisions</h3><pre>" + "\n".join(data.get("analysis_log", [])) + "</pre>"
+    html = f"""
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Research Report</title>
+        <style>
+            body {{ font-family: sans-serif; line-height: 1.6; max-width: 900px; margin: 40px auto; }}
+            h2, h3 {{ color: #2c3e50; }}
+            ul {{ padding-left: 20px; }}
+            pre {{ background: #f4f4f4; padding: 10px; border-left: 3px solid #ccc; }}
+            a {{ color: #2980b9; text-decoration: none; }}
+            a:hover {{ text-decoration: underline; }}
+        </style>
+    </head>
+    <body>
+        {answer}
+        {sources}
+        {log}
+    </body>
+    </html>
+    """
+    return html.strip()

--- a/modules/research_assistant.py
+++ b/modules/research_assistant.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+import os
+import time
+import json
+import asyncio
+import logging
+import re
+from typing import List, Dict, Any
+
+from .config import LoopConfig, SourceDoc
+from .faiss_index import SemanticMemory
+from .semantic_rank import rank_sources
+from .loop_memory import LoopMemory
+from .report_view import generate_html_report
+from .llm_engines import OpenAIEngine
+from .search_clients import SerpAPISearch
+from .extractors import TrafilaturaExtractor
+from .social_clients import TwitterExtractor
+
+"""Integrated Next-Gen Research Assistant
+Includes: FAISS Memory, Semantic Ranking, Loop Memory, HTML Report Generation
+"""
+
+class ResearchAssistant:
+    def __init__(self,
+                 llm,
+                 search_client,
+                 extractor,
+                 social_client=None,
+                 config=None,
+                 memory_layer=None,
+                 loop_logger=None,
+                 ranker=None,
+                 reporter=None):
+        self.llm = llm
+        self.search = search_client
+        self.extract = extractor
+        self.social = social_client
+        self.cfg = config or LoopConfig()
+        self.memory = memory_layer
+        self.loop_memory = loop_logger or LoopMemory()
+        self.ranker = ranker
+        self.reporter = reporter
+        self.logger = logging.getLogger("ResearchAssistant")
+
+    async def run(self, query: str) -> Dict[str, Any]:
+        """Run the research loop on a query. Returns a dict with answer, sources, etc."""
+        start_ts = time.time()
+        context: List[SourceDoc] = []
+        analysis_log: List[str] = []
+        confidence = 0.0
+
+        for loop in range(1, self.cfg.max_loops + 1):
+            self.logger.info("Loop %d/%d …", loop, self.cfg.max_loops)
+            next_action, conf = await self._decide_next_step(query, context)
+            analysis_log.append(f"<Loop {loop}> {next_action} (conf={conf:.2%})")
+            confidence = conf
+
+            # If confident enough or LLM decides to answer, stop looping
+            if confidence >= self.cfg.confidence_threshold or next_action.lower().startswith("answer"):
+                if confidence >= self.cfg.confidence_threshold:
+                    self.logger.info("Confidence %.2f >= threshold %.2f; stopping.",
+                                     confidence, self.cfg.confidence_threshold)
+                else:
+                    self.logger.info("Assistant decided to provide final answer.")
+                break
+
+            # Otherwise, treat the next_action as a new search query
+            search_query = next_action
+            self.logger.info("Searching for: %s", search_query)
+            results = await self.search.search(search_query, num_results=5)
+            docs = await self._gather_content(results)
+            context.extend(docs)
+
+            # Optional: fetch social media posts (e.g., tweets) for sentiment
+            social_docs = []
+            if self.social:
+                social_posts = await self.social.fetch_posts(search_query, limit=25)
+                social_docs = [
+                    SourceDoc(
+                        source="twitter.com",
+                        title=f"Tweet by {post.get('author_id')}",
+                        url=f"https://twitter.com/i/web/status/{post.get('id')}",
+                        content=post.get("text", "")
+                    )
+                    for post in social_posts
+                ]
+                context.extend(social_docs)
+
+            # Add new information to semantic memory
+            if self.memory:
+                new_entries = docs + social_docs
+                if new_entries:
+                    self.memory.add([d.content for d in new_entries],
+                                    [d.title for d in new_entries])
+
+        # After exiting the loop, synthesize the final answer
+        ordered_context = context
+        if self.ranker:
+            ranked_list = self.ranker(query, context)
+            ordered_context = [doc for doc, _ in ranked_list]
+        answer = await self._synthesize_answer(query, ordered_context)
+        self.logger.info("Finished in %.1fs with %d sources.", time.time() - start_ts, len(context))
+
+        result = {
+            "query": query,
+            "answer": answer,
+            "sources": [doc.dict(exclude={"content"}) for doc in ordered_context],
+            "analysis_log": analysis_log,
+            "confidence": confidence
+        }
+        # Generate an HTML report if a reporter function is provided
+        result["report"] = self.reporter({
+            "answer": answer,
+            "sources": result["sources"],
+            "analysis_log": analysis_log
+        }) if self.reporter else None
+
+        # Log the run to loop memory (with timestamp and final confidence)
+        self.loop_memory.append({
+            "query": query,
+            "timestamp": time.time(),
+            "confidence": confidence
+        })
+        return result
+
+    async def _decide_next_step(self, query: str, context: List[SourceDoc]) -> tuple[str, float]:
+        """Use LLM to decide the next action (search query or final answer)."""
+        sys_prompt = (
+            "You are an expert researcher with rigorous methodology. "
+            "Given the question and current sources, decide either:\n"
+            "1. 'answer' if there is now enough information; or\n"
+            "2. 'search: <new query>' if more information is needed.\n\n"
+            "Output MUST be JSON with fields {'action': str, 'confidence': float}. "
+            "confidence is your certainty in having enough data to answer (0-1)."
+        )
+        messages = [
+            {"role": "system", "content": sys_prompt},
+            {"role": "user", "content": f"QUESTION: {query}"},
+            {"role": "user", "content": f"CURRENT_SOURCES: {self._brief_sources(context)}"}
+        ]
+        response = await self.llm.chat(messages)
+        try:
+            data = json.loads(response)
+            action = data["action"]
+            confidence = float(data["confidence"])
+        except Exception:
+            # If parsing fails, default to doing another search with the original query
+            action = f"search: {query}"
+            confidence = 0.0
+        if action.lower().startswith("search"):
+            action = action.split("search:", 1)[1].strip()
+        return action, confidence
+
+    @staticmethod
+    def _brief_sources(ctx: List[SourceDoc], k: int = 3) -> str:
+        """Return a brief bullet list of the last k source titles in context."""
+        return "\n".join(f"- {d.title} [{d.source}]" for d in ctx[-k:])
+
+    async def _gather_content(self, raw_results: List[Dict[str, Any]]) -> List[SourceDoc]:
+        """Fetch and clean content for all search results in parallel."""
+        tasks = []
+        for item in raw_results:
+            url = item.get("link") or item.get("url")
+            title = item.get("title") or (url or "")
+            if not url:
+                continue
+            # Domain whitelisting/blacklisting
+            if self.cfg.whitelist_domains and not any(
+                url.endswith(d) or d in url for d in self.cfg.whitelist_domains
+            ):
+                continue
+            if self.cfg.blacklist_domains and any(
+                url.endswith(d) or d in url for d in self.cfg.blacklist_domains
+            ):
+                continue
+            tasks.append(self._extract_single(url, title))
+        return await asyncio.gather(*tasks, return_exceptions=False)
+
+    async def _extract_single(self, url: str, title: str) -> SourceDoc:
+        """Download and extract text from a single URL, with retries."""
+        for attempt in range(3):
+            try:
+                content = await self.extract.extract(url)
+                return SourceDoc(source=self._domain(url), title=title, url=url, content=content)
+            except Exception as e:
+                await asyncio.sleep(1.5 * (attempt + 1))
+                self.logger.warning("Retrying %s (%s)", url, e)
+        # If extraction fails after retries:
+        return SourceDoc(source=self._domain(url), title=title, url=url, content="(failed to extract)")
+
+    @staticmethod
+    def _domain(url: str) -> str:
+        """Extract the domain name from a URL for use as source identifier."""
+        return re.sub(r"https?://([^/]+)/?.*", r"\1", url)
+
+    async def _synthesize_answer(self, query: str, ctx: List[SourceDoc]) -> str:
+        """Use the LLM to synthesize a final answer with citations given the context."""
+        # Prepare citation mappings
+        cit_fmt = lambda d, i: f"[{i+1} – {d.source}]"
+        citations = {id_: cit_fmt(d, i) for i, (id_, d) in enumerate(zip(range(len(ctx)), ctx))}
+        prompt = (
+            "You are writing a well‑sourced research brief for a policymaker.\n"
+            "INSTRUCTIONS:\n"
+            "• Use plain, professional language.\n"
+            "• When asserting a fact, cite like this: (see {citation}) using the citation map given.\n"
+            "• Summarize social sentiment if available.\n"
+            "• Output 3‑5 concise paragraphs."
+        )
+        citation_map = "\n".join(f"{v}: {ctx[i].title} – {ctx[i].url}"
+                                 for i, v in enumerate(citations.values()))
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": f"QUESTION: {query}"},
+            {"role": "user", "content": f"CITATION_MAP:\n{citation_map}"},
+            {"role": "user", "content": f"SOURCES:\n{self._prepare_chunks(ctx)}"}
+        ]
+        answer = await self.llm.chat(messages)
+        # Optional hallucination guard: have the model critique its own answer
+        if self.cfg.enable_hallucination_guard:
+            guard_msg = [
+                {"role": "system", "content": (
+                    "You are a critic looking for hallucinations. "
+                    "Does the answer below cite facts that aren't in the sources? "
+                    "Respond ONLY 'ok' if safe, otherwise 'revise'."
+                )},
+                {"role": "user", "content": answer},
+                {"role": "user", "content": "\n\nSOURCES:\n" + self._prepare_chunks(ctx)}
+            ]
+            verdict = await self.llm.chat(guard_msg)
+            if "revise" in verdict.lower():
+                answer += "\n\n⚠️ Model self‑flagged potential unverifiable statements."
+        return answer
+
+    @staticmethod
+    def _prepare_chunks(ctx: List[SourceDoc], max_chars: int = 8000) -> str:
+        """Join source contents until reaching a character limit (to avoid overflow)."""
+        text_chunks = []
+        total = 0
+        for doc in ctx:
+            chunk = f"\n⎯⎯ {doc.title} ({doc.url}) ⎯⎯\n{doc.content[:2000]}"
+            total += len(chunk)
+            if total > max_chars:
+                break
+            text_chunks.append(chunk)
+        return "\n".join(text_chunks)
+
+def build_your_assistant():
+    """Factory to build a ResearchAssistant with all components."""
+    # Initialize persistent memory and loop logger
+    memory = SemanticMemory()
+    loop_log = LoopMemory()
+    # Build the research assistant with configured components
+    assistant = ResearchAssistant(
+        llm=OpenAIEngine(model="gpt-4o-mini", temperature=0.2, timeout=30.0),
+        search_client=SerpAPISearch(os.environ["SERPAPI_API_KEY"]),
+        extractor=TrafilaturaExtractor(),
+        social_client=TwitterExtractor(os.getenv("TWITTER_BEARER_TOKEN", "")) if os.getenv("TWITTER_BEARER_TOKEN") else None,
+        config=LoopConfig(),
+        memory_layer=memory,
+        loop_logger=loop_log,
+        ranker=rank_sources,
+        reporter=generate_html_report
+    )
+    return assistant
+
+# CLI Entrypoint for direct execution
+async def _amain(question: str):
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s │ %(levelname)-8s │ %(message)s")
+    assistant = build_your_assistant()
+    result = await assistant.run(question)
+    print("\n============= FINAL ANSWER =============")
+    print(result["answer"])
+    print("\n============= SOURCES ==================")
+    for i, s in enumerate(result["sources"], 1):
+        print(f"[{i}] {s['title']} – {s['url']}")
+    # Write HTML report to file if available
+    if result.get("report"):
+        with open("report.html", "w") as f:
+            f.write(result["report"])
+        print("\n📄 Full HTML report written to report.html")
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Run the AI Research Assistant")
+    parser.add_argument("question", type=str, help="The research question to answer")
+    args = parser.parse_args()
+    asyncio.run(_amain(args.question))
+
+if __name__ == "__main__":
+    main()

--- a/modules/search_clients.py
+++ b/modules/search_clients.py
@@ -1,0 +1,22 @@
+import httpx
+from typing import List, Dict, Any
+
+class SerpAPISearch:
+    """Search client using SerpAPI."""
+    BASE_URL = "https://serpapi.com/search.json"
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.client = httpx.AsyncClient(timeout=20.0)
+
+    async def search(self, query: str, num_results: int = 10) -> List[Dict[str, Any]]:
+        params = {
+            "engine": "google",
+            "q": query,
+            "api_key": self.api_key,
+            "num": num_results
+        }
+        resp = await self.client.get(self.BASE_URL, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("organic_results", [])[:num_results]

--- a/modules/semantic_rank.py
+++ b/modules/semantic_rank.py
@@ -1,0 +1,16 @@
+from typing import List, Tuple
+from .config import SourceDoc
+from .faiss_index import SemanticMemory
+
+def rank_sources(query: str, sources: List[SourceDoc]) -> List[Tuple[SourceDoc, float]]:
+    """Rank source documents by semantic similarity to the query."""
+    sm = SemanticMemory()
+    query_vec = sm.embed([query])[0]
+    results: List[Tuple[SourceDoc, float]] = []
+    for doc in sources:
+        # For large docs, use first 1000 characters for embedding
+        doc_vec = sm.embed([doc.content[:1000]])[0]
+        distance = sum((a - b) ** 2 for a, b in zip(query_vec, doc_vec)) ** 0.5
+        # Use negative distance so that higher score = more similar
+        results.append((doc, -distance))
+    return sorted(results, key=lambda x: x[1], reverse=True)

--- a/modules/social_clients.py
+++ b/modules/social_clients.py
@@ -1,0 +1,22 @@
+import httpx
+from typing import List, Dict, Any
+
+class TwitterExtractor:
+    """Twitter API client for recent tweets search."""
+    SEARCH_URL = "https://api.twitter.com/2/tweets/search/recent"
+
+    def __init__(self, bearer_token: str):
+        self.client = httpx.AsyncClient(timeout=20.0, headers={
+            "Authorization": f"Bearer {bearer_token}"
+        })
+
+    async def fetch_posts(self, query: str, limit: int = 50) -> List[Dict[str, Any]]:
+        params = {
+            "query": query,
+            "max_results": min(limit, 100),
+            "tweet.fields": "public_metrics,created_at,author_id"
+        }
+        resp = await self.client.get(self.SEARCH_URL, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("data", [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,13 @@ reportlab
 docx2txt
 PyMuPDF
 striprtf
+httpx
+pydantic
+trafilatura
+faiss-cpu
+numpy
+fastapi
+uvicorn
+tweepy
+aiofiles
+python-dotenv


### PR DESCRIPTION
## Summary
- integrate Next-Gen Research Assistant modules under `modules/`
- add Research Assistant Streamlit page
- update sidebar navigation and landing page links
- expose API secrets via `secrets.toml`
- include dependencies for the assistant

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68550669923c832cabdf3884e05cd83f