### PR TITLE
Fix ResearchAssistant module path

### DIFF
--- a/LegAid/pages/6_ResearchAssistant.py
+++ b/LegAid/pages/6_ResearchAssistant.py
@@ -1,7 +1,14 @@
 import streamlit as st
 import asyncio
 import os
+from pathlib import Path
+import sys
 from utils.navigation import render_sidebar, render_logo
+
+# Ensure the parent directory is on the Python path so ``modules`` can be
+# imported when this script is executed directly with Streamlit.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from modules.research_assistant import build_your_assistant
 from modules.report_view import generate_html_report
 


### PR DESCRIPTION
## Summary
- ensure parent directory is on `sys.path` in ResearchAssistant page

## Testing
- `python -m py_compile LegAid/pages/6_ResearchAssistant.py`


------
https://chatgpt.com/codex/tasks/task_e_6855104f75f8832caa917ec3f5ba367a