### PR TITLE
Add simple GPT chat mode

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -37,7 +37,7 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-col1, col2, col3, col4, col5, col6 = st.columns(6)
+col1, col2, col3, col4, col5, col6, col7 = st.columns(7)
 
 with col1:
     st.page_link("pages/1_CertCreate.py", label="CertCreate", icon=None)
@@ -51,4 +51,6 @@ with col5:
     st.page_link("pages/5_MailCreate.py", label="MailCreate", icon=None)
 with col6:
     st.page_link("pages/6_ResearchAssistant.py", label="Research Assistant", icon=None)
+with col7:
+    st.page_link("pages/7_ChatMode.py", label="Chat Mode", icon=None)
 

--- a/LegAid/pages/7_ChatMode.py
+++ b/LegAid/pages/7_ChatMode.py
@@ -1,0 +1,31 @@
+import os
+import streamlit as st
+from utils.navigation import render_sidebar, render_logo
+
+from modules.chat_mode import ChatBot
+
+st.set_page_config(page_title="Chat Mode", layout="wide")
+render_sidebar()
+render_logo()
+
+if "OPENAI_API_KEY" in st.secrets:
+    os.environ["OPENAI_API_KEY"] = st.secrets["OPENAI_API_KEY"]
+
+st.title("💬 Chat Mode")
+
+if "chat_history" not in st.session_state:
+    st.session_state.chat_history = []
+
+bot = ChatBot()
+
+for msg in st.session_state.chat_history:
+    st.chat_message(msg["role"]).write(msg["content"])
+
+prompt = st.chat_input("Type your message...")
+
+if prompt:
+    st.session_state.chat_history.append({"role": "user", "content": prompt})
+    st.chat_message("user").write(prompt)
+    reply, history = bot.reply(prompt, st.session_state.chat_history)
+    st.session_state.chat_history = history
+    st.chat_message("assistant").write(reply)

--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -82,6 +82,8 @@ def render_sidebar():
 
         st.page_link("pages/6_ResearchAssistant.py", label="Research Assistant", icon=None)
 
+        st.page_link("pages/7_ChatMode.py", label="Chat Mode", icon=None)
+
 
 
 def render_logo():

--- a/modules/chat_mode.py
+++ b/modules/chat_mode.py
@@ -1,0 +1,29 @@
+import os
+import openai
+from typing import List, Dict, Tuple
+
+class ChatBot:
+    """Lightweight wrapper around OpenAI ChatCompletion for quick conversations."""
+
+    def __init__(self, model: str = "gpt-4o", temperature: float = 0.5):
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        self.model = model
+        self.temperature = temperature
+
+    def reply(
+        self,
+        user_message: str,
+        history: List[Dict[str, str]] | None = None,
+        temperature: float | None = None,
+    ) -> Tuple[str, List[Dict[str, str]]]:
+        """Generate a single response and return updated history."""
+        messages = history[:] if history else []
+        messages.append({"role": "user", "content": user_message})
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature if temperature is None else temperature,
+        )
+        assistant_message = response.choices[0].message.content.strip()
+        messages.append({"role": "assistant", "content": assistant_message})
+        return assistant_message, messages


### PR DESCRIPTION
## Summary
- implement `modules/chat_mode.py` with a lightweight `ChatBot`
- add new Streamlit page `pages/7_ChatMode.py`
- update navigation and landing page to link to Chat Mode

## Testing
- `python -m py_compile modules/chat_mode.py LegAid/pages/7_ChatMode.py LegAid/app.py LegAid/utils/navigation.py`

------
https://chatgpt.com/codex/tasks/task_e_6855194dd2d4832c80d7d89a32add20a