### PR TITLE
Fix semantic ranking when embeddings fail

### DIFF
--- a/modules/semantic_rank.py
+++ b/modules/semantic_rank.py
@@ -5,12 +5,25 @@ from .faiss_index import SemanticMemory
 def rank_sources(query: str, sources: List[SourceDoc]) -> List[Tuple[SourceDoc, float]]:
     """Rank source documents by semantic similarity to the query."""
     sm = SemanticMemory()
-    query_vec = sm.embed([query])[0]
+
+    # If embedding the query fails, return original order
+    query_vecs = sm.embed([query])
+    if not query_vecs:
+        return [(doc, 0.0) for doc in sources]
+
+    query_vec = query_vecs[0]
     results: List[Tuple[SourceDoc, float]] = []
     for doc in sources:
         # For large docs, use first 1000 characters for embedding
-        doc_vec = sm.embed([doc.content[:1000]])[0]
+        doc_vecs = sm.embed([doc.content[:1000]])
+        if not doc_vecs:
+            # Skip unembeddable docs (rank them last)
+            results.append((doc, float("-inf")))
+            continue
+
+        doc_vec = doc_vecs[0]
         distance = sum((a - b) ** 2 for a, b in zip(query_vec, doc_vec)) ** 0.5
         # Use negative distance so that higher score = more similar
         results.append((doc, -distance))
+
     return sorted(results, key=lambda x: x[1], reverse=True)


### PR DESCRIPTION
## Summary
- avoid index errors if embeddings cannot be generated
- rank unembeddable sources last or keep existing order

## Testing
- `python -m py_compile modules/semantic_rank.py`
- `timeout 5s streamlit run LegAid/app.py` *(fails to detect external IP but launches)*

------
https://chatgpt.com/codex/tasks/task_e_685522be9d00832cbee39640c6349d6c