### PR TITLE
Fix missing import in navigation

### DIFF
--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -1,4 +1,4 @@
-timport streamlit as st
+import streamlit as st
 from pathlib import Path
 import base64
 


### PR DESCRIPTION
## Summary
- fix typo in `LegAid/utils/navigation.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598c6280d8832cb73636edeac0bb8a