### PR TITLE
Fix logo link

### DIFF
--- a/LegAid/utils/navigation.py
+++ b/LegAid/utils/navigation.py
@@ -70,7 +70,7 @@ def render_sidebar():
 def render_logo():
     """Render the application logo in the top-right corner."""
     st.markdown(
-        f"<a href='../app.py'><img src='data:image/png;base64,{_encoded_logo}' width='160' style='position:absolute;top:10px;right:10px;z-index:1000;'></a>",
+        f"<a href='app.py'><img src='data:image/png;base64,{_encoded_logo}' width='160' style='position:absolute;top:10px;right:10px;z-index:1000;'></a>",
         unsafe_allow_html=True,
     )
 


### PR DESCRIPTION
## Summary
- fix link in `render_logo` to point to `app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859ae042cbc832cb245c9286b3cf2d4