### PR TITLE
Fix homepage links

### DIFF
--- a/LegAid/app.py
+++ b/LegAid/app.py
@@ -56,9 +56,9 @@ st.markdown("""
 # Place buttons directly below the logo/title block
 st.markdown("""
 <div class='centered-btn-container'>
-    <button onclick="window.location.href='/1_CertCreate.py'">Certificates</button>
-    <button onclick="window.location.href='/2_SpeechCreate'">Speeches</button>
-    <button onclick="window.location.href='/3_ResponseCreate'">Responses</button>
+    <button onclick="window.location.href='1_CertCreate'">Certificates</button>
+    <button onclick="window.location.href='2_SpeechCreate'">Speeches</button>
+    <button onclick="window.location.href='3_ResponseCreate'">Responses</button>
 </div>
 """, unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- fix top page buttons to use relative URLs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859ca05004c832c90cb21bedad73a27