### PR TITLE
Fix missing GitHub dependency

### DIFF
--- a/LegAid/requirements.txt
+++ b/LegAid/requirements.txt
@@ -11,6 +11,8 @@ pdf2image
 reportlab
 PyMuPDF
 striprtf
+docx2txt
+PyGithub
 httpx
 pydantic
 trafilatura


### PR DESCRIPTION
## Summary
- include PyGithub and docx2txt in LegAid requirements to avoid runtime import errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859fa559f20832cac386d24880746a0