### PR TITLE
Set max_tokens on ChatGPT calls

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -531,7 +531,8 @@ Return ONLY valid JSON.
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": event_text}
         ],
-        temperature=0
+        temperature=0,
+        max_tokens=2000,
     )
 
     content = response.choices[0].message.content
@@ -629,7 +630,8 @@ def regenerate_certificate(cert, global_comment="", reviewer_comment=""):
     response = client.chat.completions.create(
         model=OPENAI_MODEL,
         messages=[{"role": "system", "content": system}, {"role": "user", "content": user_msg}],
-        temperature=0
+        temperature=0,
+        max_tokens=2000,
     )
 
     content = response.choices[0].message.content
@@ -707,7 +709,8 @@ def improve_certificate(cert):
     response = client.chat.completions.create(
         model=OPENAI_MODEL,
         messages=[{"role": "system", "content": system}, {"role": "user", "content": user_msg}],
-        temperature=0
+        temperature=0,
+        max_tokens=2000,
     )
     content = response.choices[0].message.content
     cleaned = content.strip().removeprefix("```json").removesuffix("```").strip()

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -133,7 +133,9 @@ if submitted:
         messages = make_speech_prompt(
             st.session_state.profile or {}, form_data, research_notes
         )
-        response = client.chat.completions.create(model=MODEL, messages=messages)
+        response = client.chat.completions.create(
+            model=MODEL, messages=messages, max_tokens=2000
+        )
         draft = response.choices[0].message.content.strip()
         st.session_state.speech_draft = draft
         st.session_state.orig_draft = draft
@@ -171,7 +173,7 @@ if st.session_state.speech_draft:
             {"role": "user", "content": st.session_state.final_text},
         ]
         resp = client.chat.completions.create(
-            model=MODEL, messages=sum_messages, temperature=0.3
+            model=MODEL, messages=sum_messages, temperature=0.3, max_tokens=2000
         )
         points = resp.choices[0].message.content.strip()
         slug = datetime.now().strftime("%Y-%m-%d_%H%M")

--- a/SpeechCreate.py
+++ b/SpeechCreate.py
@@ -130,7 +130,9 @@ if submitted:
         messages = make_speech_prompt(
             st.session_state.profile or {}, form_data, research_notes
         )
-        response = client.chat.completions.create(model=MODEL, messages=messages)
+        response = client.chat.completions.create(
+            model=MODEL, messages=messages, max_tokens=2000
+        )
 
         draft = response.choices[0].message.content.strip()
         st.session_state.speech_draft = draft
@@ -170,7 +172,7 @@ if st.session_state.speech_draft:
             {"role": "user", "content": st.session_state.final_text},
         ]
         resp = client.chat.completions.create(
-            model=MODEL, messages=sum_messages, temperature=0.3
+            model=MODEL, messages=sum_messages, temperature=0.3, max_tokens=2000
         )
         points = resp.choices[0].message.content.strip()
         slug = datetime.now().strftime("%Y-%m-%d_%H%M")

--- a/flyer_ocr_parser.py
+++ b/flyer_ocr_parser.py
@@ -69,6 +69,7 @@ def parse_certificate(text: str) -> list:
             {"role": "user", "content": text},
         ],
         temperature=0,
+        max_tokens=2000,
     )
     content = response.choices[0].message.content
     cleaned = content.strip().removeprefix("```json").removesuffix("```").strip()

--- a/modules/chat_mode.py
+++ b/modules/chat_mode.py
@@ -23,6 +23,7 @@ class ChatBot:
             model=self.model,
             messages=messages,
             temperature=self.temperature if temperature is None else temperature,
+            max_tokens=2000,
         )
         assistant_message = response.choices[0].message.content.strip()
         messages.append({"role": "assistant", "content": assistant_message})

--- a/modules/llm_engines.py
+++ b/modules/llm_engines.py
@@ -15,6 +15,7 @@ class OpenAIEngine:
             model=self.model,
             messages=messages,
             temperature=self.temperature,
-            timeout=self.timeout
+            timeout=self.timeout,
+            max_tokens=2000,
         )
         return response.choices[0].message.content.strip()

--- a/parallel-task-agent/agent/llm_integration.py
+++ b/parallel-task-agent/agent/llm_integration.py
@@ -15,6 +15,7 @@ def decompose_task(description: str) -> List[str]:
     res = client.chat.completions.create(
         model=MODEL,
         messages=[{"role": "user", "content": prompt}],
+        max_tokens=2000,
     )
     commands = res.choices[0].message.content.splitlines()
     return [c.strip() for c in commands if c.strip()]

--- a/speech_creator/voice_profile.py
+++ b/speech_creator/voice_profile.py
@@ -31,7 +31,7 @@ def generate_profile_from_text(text: str, name: str) -> dict:
 
     client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     resp = client.chat.completions.create(
-        model="gpt-4o", messages=messages, temperature=0.2
+        model="gpt-4o", messages=messages, temperature=0.2, max_tokens=2000
     )
 
     content = resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- enforce a consistent `max_tokens=2000` limit for all calls to `openai.ChatCompletion.create`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1cd554a0832c93c67237bd166bf1