### PR TITLE
Add research assistant logging

### DIFF
--- a/SpeechCreate.py
+++ b/SpeechCreate.py
@@ -7,6 +7,7 @@ import os
 
 import streamlit as st
 import openai
+import logging
 from docx import Document
 
 from speech_creator.file_utils import extract_text
@@ -16,6 +17,17 @@ from speech_creator.prompt_builder import make_speech_prompt
 
 if "OPENAI_API_KEY" in st.secrets:
     os.environ["OPENAI_API_KEY"] = st.secrets["OPENAI_API_KEY"]
+
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s │ %(levelname)-8s │ %(name)s │ %(message)s",
+        handlers=[
+            logging.FileHandler("speech.log"),
+            logging.StreamHandler(),
+        ],
+    )
+logger = logging.getLogger(__name__)
 
 client = openai.OpenAI()
 MODEL = "gpt-4o"
@@ -217,6 +229,7 @@ elif step == 7:
                 st.warning(f"Research assistant unavailable: {e}")
                 research_notes = None
             except Exception:
+                logging.exception("Research assistant failed")
                 st.warning("Failed to gather research notes.")
                 research_notes = None
 

--- a/modules/research_assistant.py
+++ b/modules/research_assistant.py
@@ -245,6 +245,20 @@ class ResearchAssistant:
             text_chunks.append(chunk)
         return "\n".join(text_chunks)
 
+def setup_logging(log_file: str = "research.log") -> None:
+    """Configure root logging if no handlers are present."""
+    root = logging.getLogger()
+    if not root.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s │ %(levelname)-8s │ %(name)s │ %(message)s",
+            handlers=[
+                logging.FileHandler(log_file),
+                logging.StreamHandler(),
+            ],
+        )
+
+
 def build_your_assistant():
     """Factory to build a ResearchAssistant with all components."""
     # Initialize persistent memory and loop logger
@@ -268,14 +282,18 @@ def build_your_assistant():
     return assistant
 
 
-def gather_info(topic: str) -> str:
+def gather_info(topic: str, log_file: str = "research.log") -> str:
     """Run the research assistant on ``topic`` and return the answer text."""
+    setup_logging(log_file)
+    logger = logging.getLogger(__name__)
+    logger.info("Gathering research notes for '%s'", topic)
     assistant = build_your_assistant()
     loop = asyncio.new_event_loop()
     try:
         result = loop.run_until_complete(assistant.run(topic))
     finally:
         loop.close()
+    logger.info("Finished gathering notes")
     return result.get("answer", "")
 
 # CLI Entrypoint for direct execution


### PR DESCRIPTION
## Summary
- configure logging for SpeechCreate
- add log setup in research assistant and log gather_info stages
- log uncaught errors when research notes retrieval fails

## Testing
- `python -m py_compile modules/research_assistant.py SpeechCreate.py`

------
https://chatgpt.com/codex/tasks/task_e_685b7ceb7168832cb85d778e9d1a0fbd