### PR TITLE
Ensure research assistant logging always persists

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,5 @@ streamlit run SpeechCreate.py
 ```
 
 After generating a draft you can download the speech and bullet‑point notes or push the files to GitHub.
+
+Any research performed by the speech generator is logged to `research.log` in the project root.

--- a/modules/research_assistant.py
+++ b/modules/research_assistant.py
@@ -245,18 +245,25 @@ class ResearchAssistant:
             text_chunks.append(chunk)
         return "\n".join(text_chunks)
 
-def setup_logging(log_file: str = "research.log") -> None:
-    """Configure root logging if no handlers are present."""
-    root = logging.getLogger()
-    if not root.handlers:
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s │ %(levelname)-8s │ %(name)s │ %(message)s",
-            handlers=[
-                logging.FileHandler(log_file),
-                logging.StreamHandler(),
-            ],
+def setup_logging(log_file: str = "research.log") -> logging.Logger:
+    """Return a logger that always writes to ``log_file``."""
+    logger = logging.getLogger("ResearchAssistant")
+    logger.setLevel(logging.INFO)
+
+    # Ensure a file handler for the research log is attached
+    log_path = os.path.abspath(log_file)
+    has_file = any(
+        isinstance(h, logging.FileHandler) and os.path.abspath(getattr(h, "baseFilename", "")) == log_path
+        for h in logger.handlers
+    )
+    if not has_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s │ %(levelname)-8s │ %(name)s │ %(message)s")
         )
+        logger.addHandler(file_handler)
+
+    return logger
 
 
 def build_your_assistant():
@@ -284,8 +291,7 @@ def build_your_assistant():
 
 def gather_info(topic: str, log_file: str = "research.log") -> str:
     """Run the research assistant on ``topic`` and return the answer text."""
-    setup_logging(log_file)
-    logger = logging.getLogger(__name__)
+    logger = setup_logging(log_file)
     logger.info("Gathering research notes for '%s'", topic)
     assistant = build_your_assistant()
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Summary
- create a dedicated `ResearchAssistant` logger
- attach a `FileHandler('research.log')` if not already present
- use this logger in `gather_info`
- note logging behaviour in README

## Testing
- `pytest`
- `SERPAPI_API_KEY=foo OPENAI_API_KEY=bar python - <<'PY'
from modules import research_assistant
try:
    research_assistant.gather_info('test topic')
except Exception as e:
    print('gather_info failed:', type(e).__name__, e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685b80ff4034832cadf81ac2b5223e01