### PR TITLE
feat: switch to gpt-5-mini model

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -28,7 +28,7 @@ from striprtf.striprtf import rtf_to_text
 import random
 
 client = openai.OpenAI()
-OPENAI_MODEL = "gpt-4o"
+OPENAI_MODEL = "gpt-5-mini"
 
 if "google_vision_key" not in st.secrets:
     st.error("Add `google_vision_key` to your Streamlit secrets to enable OCR.")

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -29,7 +29,7 @@ if "OPENAI_API_KEY" in st.secrets:
 import openai
 
 client = openai.OpenAI()
-MODEL = "gpt-4o"
+MODEL = "gpt-5-mini"
 
 st.set_page_config(page_title="SpeechCreate", layout="wide")
 render_sidebar()

--- a/SpeechCreate.py
+++ b/SpeechCreate.py
@@ -43,7 +43,7 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 client = openai.OpenAI()
-MODEL = "gpt-4o"
+MODEL = "gpt-5-mini"
 
 st.set_page_config(page_title="Speech Creator", layout="wide")
 st.title("🗣️ Speech Creator")

--- a/flyer_ocr_parser.py
+++ b/flyer_ocr_parser.py
@@ -63,7 +63,7 @@ def parse_certificate(text: str) -> list:
     text = normalize_date_strings(text)
     client = openai.OpenAI()
     response = client.chat.completions.create(
-        model="gpt-4o",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": text},

--- a/modules/chat_mode.py
+++ b/modules/chat_mode.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Tuple
 class ChatBot:
     """Lightweight wrapper around the OpenAI chat API for quick conversations."""
 
-    def __init__(self, model: str = "gpt-4o", temperature: float = 0.5):
+    def __init__(self, model: str = "gpt-5-mini", temperature: float = 0.5):
         self.client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         self.model = model
         self.temperature = temperature

--- a/modules/config.py
+++ b/modules/config.py
@@ -10,7 +10,7 @@ class LoopConfig:
     whitelist_domains: Sequence[str] | None = None  # e.g., (".gov", ".edu")
     blacklist_domains: Sequence[str] | None = None
     enable_hallucination_guard: bool = True
-    llm_model: str = "gpt-4o"
+    llm_model: str = "gpt-5-mini"
     llm_temperature: float = 0.5
     request_timeout: float = 30.0  # seconds
 

--- a/modules/research_assistant.py
+++ b/modules/research_assistant.py
@@ -276,7 +276,7 @@ def build_your_assistant():
     if not serp_key:
         raise RuntimeError("SERPAPI_API_KEY environment variable is not set")
     assistant = ResearchAssistant(
-        llm=OpenAIEngine(model="gpt-4o-mini", temperature=0.6, timeout=30.0),
+        llm=OpenAIEngine(model="gpt-5-mini", temperature=0.6, timeout=30.0),
         search_client=SerpAPISearch(serp_key),
         extractor=TrafilaturaExtractor(),
         social_client=TwitterExtractor(os.getenv("TWITTER_BEARER_TOKEN", "")) if os.getenv("TWITTER_BEARER_TOKEN") else None,

--- a/parallel-task-agent/README.md
+++ b/parallel-task-agent/README.md
@@ -7,7 +7,7 @@ This directory contains an autonomous coding agent designed to execute coding ta
 - **Ephemeral Kubernetes Sandboxes** – each task runs in its own container launched via `k8s_launcher.py`.
 - **Task Queue** – RabbitMQ limits each user to 3–5 concurrent tasks.
 - **Secure Execution** – sandboxes use `nsjail` and Kubernetes NetworkPolicies to restrict outbound traffic to GitHub, PyPI and NPM.
-- **GPT‑4 Turbo Integration** – `llm_integration.py` decomposes tasks and generates code.
+- **GPT‑5 Mini Integration** – `llm_integration.py` decomposes tasks and generates code.
 - **Diff Validation** – `validate_diff.py` enforces code style with ESLint, Black and Pylint before tests run.
 - **Secrets Handling** – HashiCorp Vault provides short‑lived credentials.
 - **Audit Logging** – all actions are recorded to immutable CloudWatch Trails.

--- a/parallel-task-agent/agent/llm_integration.py
+++ b/parallel-task-agent/agent/llm_integration.py
@@ -2,7 +2,7 @@ import os
 from typing import List
 import openai
 
-MODEL = "gpt-4-turbo"
+MODEL = "gpt-5-mini"
 
 
 def decompose_task(description: str) -> List[str]:

--- a/speech_creator/voice_profile.py
+++ b/speech_creator/voice_profile.py
@@ -31,7 +31,7 @@ def generate_profile_from_text(text: str, name: str) -> dict:
 
     client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     resp = client.chat.completions.create(
-        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=2000
+        model="gpt-5-mini", messages=messages, temperature=0.7, max_tokens=2000
     )
 
     content = resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- use gpt-5-mini for certificate parsing and speech creation modules
- update research agent, chat bot, and task agent defaults to gpt-5-mini
- note new gpt-5-mini model in task agent documentation

## Testing
- `python -m py_compile flyer_ocr_parser.py SpeechCreate.py LegAid/pages/1_CertCreate.py LegAid/pages/2_SpeechCreate.py modules/chat_mode.py modules/research_assistant.py modules/config.py speech_creator/voice_profile.py parallel-task-agent/agent/llm_integration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05c19ddc4832c9e2d21eab1cab833