### PR TITLE
chore: use gpt-4o-mini model

### DIFF
--- a/LegAid/pages/1_CertCreate.py
+++ b/LegAid/pages/1_CertCreate.py
@@ -28,7 +28,7 @@ from striprtf.striprtf import rtf_to_text
 import random
 
 client = openai.OpenAI()
-OPENAI_MODEL = "gpt-5-mini"
+OPENAI_MODEL = "gpt-4o-mini"
 
 if "google_vision_key" not in st.secrets:
     st.error("Add `google_vision_key` to your Streamlit secrets to enable OCR.")

--- a/LegAid/pages/2_SpeechCreate.py
+++ b/LegAid/pages/2_SpeechCreate.py
@@ -29,7 +29,7 @@ if "OPENAI_API_KEY" in st.secrets:
 import openai
 
 client = openai.OpenAI()
-MODEL = "gpt-5-mini"
+MODEL = "gpt-4o-mini"
 
 st.set_page_config(page_title="SpeechCreate", layout="wide")
 render_sidebar()

--- a/SpeechCreate.py
+++ b/SpeechCreate.py
@@ -43,7 +43,7 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 client = openai.OpenAI()
-MODEL = "gpt-5-mini"
+MODEL = "gpt-4o-mini"
 
 st.set_page_config(page_title="Speech Creator", layout="wide")
 st.title("🗣️ Speech Creator")

--- a/flyer_ocr_parser.py
+++ b/flyer_ocr_parser.py
@@ -63,7 +63,7 @@ def parse_certificate(text: str) -> list:
     text = normalize_date_strings(text)
     client = openai.OpenAI()
     response = client.chat.completions.create(
-        model="gpt-5-mini",
+        model="gpt-4o-mini",
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": text},

--- a/modules/chat_mode.py
+++ b/modules/chat_mode.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Tuple
 class ChatBot:
     """Lightweight wrapper around the OpenAI chat API for quick conversations."""
 
-    def __init__(self, model: str = "gpt-5-mini", temperature: float = 0.5):
+    def __init__(self, model: str = "gpt-4o-mini", temperature: float = 0.5):
         self.client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         self.model = model
         self.temperature = temperature

--- a/modules/config.py
+++ b/modules/config.py
@@ -10,7 +10,7 @@ class LoopConfig:
     whitelist_domains: Sequence[str] | None = None  # e.g., (".gov", ".edu")
     blacklist_domains: Sequence[str] | None = None
     enable_hallucination_guard: bool = True
-    llm_model: str = "gpt-5-mini"
+    llm_model: str = "gpt-4o-mini"
     llm_temperature: float = 0.5
     request_timeout: float = 30.0  # seconds
 

--- a/modules/research_assistant.py
+++ b/modules/research_assistant.py
@@ -276,7 +276,7 @@ def build_your_assistant():
     if not serp_key:
         raise RuntimeError("SERPAPI_API_KEY environment variable is not set")
     assistant = ResearchAssistant(
-        llm=OpenAIEngine(model="gpt-5-mini", temperature=0.6, timeout=30.0),
+        llm=OpenAIEngine(model="gpt-4o-mini", temperature=0.6, timeout=30.0),
         search_client=SerpAPISearch(serp_key),
         extractor=TrafilaturaExtractor(),
         social_client=TwitterExtractor(os.getenv("TWITTER_BEARER_TOKEN", "")) if os.getenv("TWITTER_BEARER_TOKEN") else None,

--- a/parallel-task-agent/agent/llm_integration.py
+++ b/parallel-task-agent/agent/llm_integration.py
@@ -2,7 +2,7 @@ import os
 from typing import List
 import openai
 
-MODEL = "gpt-5-mini"
+MODEL = "gpt-4o-mini"
 
 
 def decompose_task(description: str) -> List[str]:

--- a/speech_creator/voice_profile.py
+++ b/speech_creator/voice_profile.py
@@ -31,7 +31,7 @@ def generate_profile_from_text(text: str, name: str) -> dict:
 
     client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     resp = client.chat.completions.create(
-        model="gpt-5-mini", messages=messages, temperature=0.7, max_tokens=2000
+        model="gpt-4o-mini", messages=messages, temperature=0.7, max_tokens=2000
     )
 
     content = resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- set gpt-4o-mini as the default OpenAI model across certificate app components

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c06160e8c4832ca55924f856dec117