### PR TITLE
Handle JSON parsing when LLM responses include code fences

### DIFF
--- a/flyer_ocr_parser.py
+++ b/flyer_ocr_parser.py
@@ -8,7 +8,7 @@ import base64
 import requests
 import openai
 
-from LegAid.utils.shared_functions import normalize_date_strings
+from LegAid.utils.shared_functions import normalize_date_strings, extract_json_block
 
 
 if not os.getenv("OPENAI_API_KEY"):
@@ -72,7 +72,10 @@ def parse_certificate(text: str) -> list:
         max_tokens=2000,
     )
     content = response.choices[0].message.content
-    cleaned = content.strip().removeprefix("```json").removesuffix("```").strip()
+    try:
+        cleaned = extract_json_block(content)
+    except ValueError as exc:
+        raise json.JSONDecodeError(str(exc), content, 0) from exc
     return json.loads(cleaned)
 
 


### PR DESCRIPTION
## Summary
- add a shared helper that extracts the JSON payload from LLM responses even when wrapped in code fences or explanations
- update certificate generation, regeneration, and manual improvement flows to rely on the new helper and surface clearer errors
- reuse the helper in the flyer OCR parser so JSON responses are parsed consistently

## Testing
- python -m compileall LegAid/utils/shared_functions.py flyer_ocr_parser.py LegAid/pages/1_CertCreate.py

------
https://chatgpt.com/codex/tasks/task_e_68c83f81c878832c86fc206b02eba4d8