### PR TITLE
Improve JSON extraction handling

### DIFF
--- a/LegAid/__init__.py
+++ b/LegAid/__init__.py
@@ -1,0 +1,1 @@
+"""LegAid application package."""

--- a/LegAid/utils/__init__.py
+++ b/LegAid/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for LegAid."""

--- a/LegAid/utils/shared_functions.py
+++ b/LegAid/utils/shared_functions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime
 from dateutil import parser as date_parser
@@ -16,8 +17,8 @@ def extract_json_block(content: str) -> str:
     """Return the JSON payload embedded in an LLM response.
 
     Many model responses include code fences or short explanations
-    before the actual JSON. This helper strips common wrappers and
-    returns the first balanced JSON object or array it can find.
+    before the actual JSON. This helper strips common wrappers and then
+    scans the remaining text for the first *valid* JSON object or array.
 
     Raises:
         ValueError: If no JSON content can be located or the JSON block
@@ -43,52 +44,25 @@ def extract_json_block(content: str) -> str:
                 lower = text.lower()
                 break
 
-    def _first_json_start(value: str) -> int | None:
-        positions = [pos for pos in (value.find("{"), value.find("[")) if pos != -1]
-        if not positions:
-            return None
-        return min(positions)
+    decoder = json.JSONDecoder()
+    saw_candidate = False
 
-    start_index = _first_json_start(text)
-    if start_index is None:
-        raise ValueError("No JSON object or array found in response.")
+    for match in re.finditer(r"[\[{]", text):
+        candidate_start = match.start()
+        try:
+            _, end = decoder.raw_decode(text[candidate_start:])
+        except json.JSONDecodeError:
+            saw_candidate = True
+            continue
 
-    def _slice_balanced(value: str, idx: int) -> str:
-        stack: list[str] = []
-        in_string = False
-        escape = False
-        result: list[str] = []
+        snippet = text[candidate_start : candidate_start + end].strip()
+        if snippet:
+            return snippet
 
-        for ch in value[idx:]:
-            result.append(ch)
-
-            if in_string:
-                if escape:
-                    escape = False
-                elif ch == "\\":
-                    escape = True
-                elif ch == '"':
-                    in_string = False
-                continue
-
-            if ch == '"':
-                in_string = True
-            elif ch in "{[":
-                stack.append(ch)
-            elif ch in "}]":
-                if not stack:
-                    raise ValueError("Unexpected closing bracket while parsing JSON.")
-                opener = stack.pop()
-                if opener == "{" and ch != "}":
-                    raise ValueError("Mismatched JSON braces in response.")
-                if opener == "[" and ch != "]":
-                    raise ValueError("Mismatched JSON brackets in response.")
-                if not stack:
-                    return "".join(result)
-
+    if saw_candidate:
         raise ValueError("JSON content appears to be truncated in the response.")
 
-    return _slice_balanced(text, start_index).strip()
+    raise ValueError("No JSON object or array found in response.")
 
 
 def normalize_date_strings(text: str) -> str:

--- a/tests/test_shared_functions.py
+++ b/tests/test_shared_functions.py
@@ -1,0 +1,35 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from LegAid.utils.shared_functions import extract_json_block
+
+
+def test_extract_json_block_from_code_fence():
+    content = """
+    ```json
+    {"foo": [1, 2, 3]}
+    ```
+    Extra commentary.
+    """
+
+    cleaned = extract_json_block(content)
+    assert json.loads(cleaned) == {"foo": [1, 2, 3]}
+
+
+def test_extract_json_block_skips_non_json_curly_section():
+    content = "Sure, here is what I found {not real json}. {\"valid\": true}"
+
+    cleaned = extract_json_block(content)
+    assert json.loads(cleaned) == {"valid": True}
+
+
+def test_extract_json_block_reports_truncated_content():
+    with pytest.raises(ValueError) as excinfo:
+        extract_json_block("Result begins { but never ends")
+
+    assert "truncated" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- make `extract_json_block` scan for the first valid JSON segment instead of stopping at an unmatched brace
- add package initializers so shared utilities can be imported in tests
- cover JSON extraction edge cases with pytest tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c87ac37a3c832c9c495c7563e490a5