### PR TITLE
[Execute] 2025-09-16 – <PL1>

### DIFF
--- a/dr_rd/__init__.py
+++ b/dr_rd/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for document review and record digestion."""
+
+from .record_parser import parse_key_value_lines, split_records
+
+__all__ = ["parse_key_value_lines", "split_records"]

--- a/dr_rd/record_parser.py
+++ b/dr_rd/record_parser.py
@@ -1,0 +1,162 @@
+"""Helpers for parsing loosely structured key-value records."""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Dict, List, MutableMapping
+
+Value = str | List[str]
+Normalizer = Callable[[str], str]
+
+_BULLET_PATTERN = re.compile(
+    r"""
+    ^(
+        (?:[\-\*\u2022\u2023\u2043]+)    # bullet characters
+        |
+        (?:\d+\.)                        # numbered list
+        |
+        (?:[A-Za-z]\))                    # alpha enumerations
+    )\s+
+    """,
+    re.VERBOSE,
+)
+
+_DASH_SEPARATOR = re.compile(r"\s[-–—]\s")
+
+
+def _default_normalizer(key: str) -> str:
+    cleaned = re.sub(r"[^0-9a-z]+", "_", key.lower())
+    return cleaned.strip("_")
+
+
+def _strip_bullet(line: str) -> tuple[str, bool]:
+    stripped = line.lstrip()
+    match = _BULLET_PATTERN.match(stripped)
+    if match:
+        return stripped[match.end() :], True
+    return stripped, False
+
+
+def _extract_key_value(line: str) -> tuple[str, str, bool] | None:
+    candidate, was_bullet = _strip_bullet(line)
+    if not candidate.strip():
+        return None
+
+    for sep in (":", "="):
+        if sep in candidate:
+            key, value = candidate.split(sep, 1)
+            key = key.strip()
+            if not key:
+                continue
+            return key, value.strip(), was_bullet
+
+    dash_match = _DASH_SEPARATOR.search(candidate)
+    if dash_match:
+        key = candidate[: dash_match.start()].strip()
+        value = candidate[dash_match.end() :].strip()
+        if key:
+            return key, value, was_bullet
+
+    return None
+
+
+def parse_key_value_lines(
+    text: str,
+    *,
+    key_normalizer: Normalizer | None = None,
+) -> Dict[str, Value]:
+    """Parse a block of text into a dictionary of normalized keys.
+
+    Lines that begin with bullet characters or numbering are treated as
+    continuations of the previous key unless they contain a recognised
+    separator. Repeated keys produce a list preserving the order of the
+    values encountered.
+    """
+
+    normalizer = key_normalizer or _default_normalizer
+    aggregated: MutableMapping[str, List[str]] = {}
+    current_key: str | None = None
+
+    for raw_line in text.splitlines():
+        if not raw_line.strip():
+            current_key = None
+            continue
+
+        parsed = _extract_key_value(raw_line)
+        if parsed:
+            key_text, value_text, _ = parsed
+            norm_key = normalizer(key_text)
+            if not norm_key:
+                current_key = None
+                continue
+
+            bucket = aggregated.setdefault(norm_key, [])
+            if value_text:
+                bucket.append(value_text)
+            else:
+                bucket.append("")
+            current_key = norm_key
+            continue
+
+        if current_key is None:
+            continue
+
+        continuation, is_bullet = _strip_bullet(raw_line)
+        continuation = continuation.strip()
+        if not continuation:
+            continue
+
+        bucket = aggregated[current_key]
+        if not bucket:
+            bucket.append(continuation)
+            continue
+
+        last = bucket[-1]
+        if not last:
+            bucket[-1] = continuation
+        elif is_bullet:
+            bucket[-1] = f"{last}\n{continuation}"
+        else:
+            bucket[-1] = f"{last} {continuation}".strip()
+
+    result: Dict[str, Value] = {}
+    for key, values in aggregated.items():
+        cleaned = [value.strip() for value in values if value.strip()]
+        if not cleaned:
+            continue
+        result[key] = cleaned[0] if len(cleaned) == 1 else cleaned
+
+    return result
+
+
+def split_records(
+    text: str,
+    *,
+    key_normalizer: Normalizer | None = None,
+) -> List[Dict[str, Value]]:
+    """Split multi-record text into structured dictionaries.
+
+    Blank lines delimit records. Empty records are ignored.
+    """
+
+    records: List[Dict[str, Value]] = []
+    buffer: List[str] = []
+
+    def flush() -> None:
+        if not buffer:
+            return
+        block = "\n".join(buffer)
+        parsed = parse_key_value_lines(block, key_normalizer=key_normalizer)
+        if parsed:
+            records.append(parsed)
+        buffer.clear()
+
+    for line in text.splitlines():
+        if line.strip():
+            buffer.append(line)
+        else:
+            flush()
+
+    flush()
+    return records
+

--- a/tests/test_record_parser.py
+++ b/tests/test_record_parser.py
@@ -1,0 +1,91 @@
+"""Tests for the dr_rd.record_parser module."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dr_rd.record_parser import parse_key_value_lines, split_records
+
+
+def test_parse_key_value_lines_handles_mixed_separators_and_continuations() -> None:
+    """The parser should normalize keys and combine wrapped values."""
+
+    text = """
+    Name: Alice Johnson
+    Title – Director of Outreach
+    Organization: Community Helpers
+    Notes:
+        Leads the volunteer program
+        Coordinates events across the county
+    """
+
+    result = parse_key_value_lines(text)
+
+    assert result["name"] == "Alice Johnson"
+    assert result["title"] == "Director of Outreach"
+    assert result["organization"] == "Community Helpers"
+    assert result["notes"] == "Leads the volunteer program Coordinates events across the county"
+
+
+def test_parse_key_value_lines_accumulates_repeated_keys() -> None:
+    """Repeated keys should be returned as a list preserving order."""
+
+    text = """
+    Award: Service Medal
+    Award: Volunteer of the Year
+    Award - Community Impact Citation
+    """
+
+    result = parse_key_value_lines(text)
+
+    assert result["award"] == [
+        "Service Medal",
+        "Volunteer of the Year",
+        "Community Impact Citation",
+    ]
+
+
+def test_parse_key_value_lines_preserves_bullet_lists() -> None:
+    """Bullet lines should be kept on separate lines for readability."""
+
+    text = """
+    Highlights:
+      - Led the robotics team
+      - Organized outreach events
+      - Mentored new volunteers
+    """
+
+    result = parse_key_value_lines(text)
+
+    assert result["highlights"] == (
+        "Led the robotics team\n"
+        "Organized outreach events\n"
+        "Mentored new volunteers"
+    )
+
+
+def test_split_records_breaks_on_blank_lines() -> None:
+    """Multiple records separated by blank lines should be parsed individually."""
+
+    text = """
+    Name: Jordan Smith
+    Title: Captain
+
+    Name: Priya Patel
+    Title: Director of Outreach
+    Award: Service Medal
+    Award: Community Volunteer of the Year
+    """
+
+    records = split_records(text)
+
+    assert len(records) == 2
+    assert records[0]["name"] == "Jordan Smith"
+    assert records[0]["title"] == "Captain"
+    assert records[1]["name"] == "Priya Patel"
+    assert records[1]["title"] == "Director of Outreach"
+    assert records[1]["award"] == [
+        "Service Medal",
+        "Community Volunteer of the Year",
+    ]


### PR DESCRIPTION
## Summary
- add a dr_rd.record_parser module that normalizes key-value text blocks into structured dictionaries and preserves bullet-style continuations
- cover parsing behaviour with tests for repeated keys, mixed separators, bullet lists, and record splitting utilities

## Testing
- pytest -q
- mypy dr_rd
- ruff check dr_rd
- gitleaks detect --source . *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c96612f0832c8c32a95d3b45c07c